### PR TITLE
v0.2.10 - Sockets, proper structs for messages+datagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ Clears the /saves directory
 See README.md :)
 
 ## Known bugs
-- Program deadlocks on failed ping
 - Save files may break with newer versions (Future fix: Version files, no breaking changes in minor versions)
 
 ## Version History
 What has been accomplished at each major.minor version
+
+### v0.2.10 - September 30, 2024
+Structs for messages and datagrams, sockets for internal application-layer communication
 
 ### v0.2.9 - September 27, 2024
 DHCP improvements, router control, router pinging

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ See README.md :)
 ## Known bugs
 - Program deadlocks on failed ping
 - Save files may break with newer versions (Future fix: Version files, no breaking changes in minor versions)
-- Router hangs when pinging itself (Future fix: Multiple internal channels, similar to ports)
 
 ## Version History
 What has been accomplished at each major.minor version

--- a/USER-MANUAL
+++ b/USER-MANUAL
@@ -1,6 +1,6 @@
 ===============
 ltdnet manual
-v0.2.9
+v0.2.10
 ===============
 
 Welcome to ltdnet! Using this program, you can simulate a LAN (Local Area Network) with virtual computers, switches, and routers. ltdnet features fictional device models, such as the ProBox, a state-of-the-art PC workstation, and the Bobcat 100, a sturdy small business router (with no recurring license fees!).

--- a/actions.go
+++ b/actions.go
@@ -506,3 +506,9 @@ func ipset(hostname string) {
 	}
 
 }
+
+// Run an ARP request, but synchronize with client
+func arpSynchronized(id string, targetIP string) {
+	arp_request(id, targetIP)
+	actionsync[id] <- 1
+}

--- a/client.go
+++ b/client.go
@@ -319,7 +319,7 @@ func actionsMenu() {
 			confirmation := scanner.Text()
 			confirmation = strings.ToUpper(confirmation)
 			if confirmation == "Y" {
-				delRouter(actionword3) //Placeholder. Only one router per network currently
+				delRouter() // Only one router per network currently
 				save()
 			}
 
@@ -477,7 +477,7 @@ func main() {
 		<-listenSync
 	}
 	fmt.Printf("\n[Notice] Debug level is set to %d\n", getDebug())
-	fmt.Println("\nPlease type an action:")
+	fmt.Println("\nltdnetOS:")
 
 	for {
 		actionsMenu()

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 func intro() {
-	fmt.Println("ltdnet v0.2.9")
+	fmt.Println("ltdnet v0.2.10")
 	fmt.Println("by vincebel")
 	fmt.Println("\nPlease note that switch functionality is limited and in development")
 }

--- a/connhost.go
+++ b/connhost.go
@@ -74,6 +74,19 @@ func HostConn(device string, id string) {
 						fmt.Println("Usage: ping <dest_ip> [seconds]")
 					}
 				}
+			case "arp":
+				if host.UplinkID == "" {
+					fmt.Println("Device is not connected. Please set an uplink")
+				} else if (host.IPAddr.String() == "0.0.0.0") || (host.IPAddr == nil) {
+					fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")
+				} else {
+					if len(action) > 1 {
+						go arpSynchronized(id, action[1])
+						<-actionsync[id]
+					} else {
+						fmt.Println("Usage: arp <target_ip>")
+					}
+				}
 			case "dhcp":
 				if host.UplinkID == "" {
 					fmt.Println("Device is not connected. Please set an uplink")

--- a/connhost.go
+++ b/connhost.go
@@ -63,15 +63,15 @@ func HostConn(device string, id string) {
 					fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")
 				} else {
 					if len(action) > 1 {
-						if len(action) > 2 { //if seconds is specified
-							seconds, _ := strconv.Atoi(action[2])
-							go ping(host.ID, action[1], seconds)
+						if len(action) > 2 { //if count is specified
+							count, _ := strconv.Atoi(action[2])
+							go ping(host.ID, action[1], count)
 						} else {
 							go ping(host.ID, action[1], 4)
 						}
 						<-actionsync[id]
 					} else {
-						fmt.Println("Usage: ping <dest_ip> [seconds]")
+						fmt.Println("Usage: ping <dest_ip> [count]")
 					}
 				}
 			case "arp":

--- a/connhost.go
+++ b/connhost.go
@@ -1,6 +1,6 @@
 /*
 File:		connhost.go
-Author: 	https://bitbucket.org/vincebel
+Author: 	https://github.com/vincebel7
 Purpose:	Handles connection and interface for hosts
 */
 

--- a/connhost.go
+++ b/connhost.go
@@ -78,7 +78,6 @@ func HostConn(device string, id string) {
 				if host.UplinkID == "" {
 					fmt.Println("Device is not connected. Please set an uplink")
 				} else {
-
 					go dhcp_discover(host)
 					<-actionsync[id]
 					save()

--- a/connrouter.go
+++ b/connrouter.go
@@ -51,6 +51,17 @@ func RouterConn(device string, id string) {
 						fmt.Println("Usage: ping <dest_ip> [seconds]")
 					}
 				}
+			case "arp":
+				if (snet.Router.Gateway.String() == "0.0.0.0") || (snet.Router.Gateway == nil) {
+					fmt.Println("Device does not have IP configuration. Please statically assign an IP configuration")
+				} else {
+					if len(action) > 1 {
+						go arpSynchronized(id, action[1])
+						<-actionsync[id]
+					} else {
+						fmt.Println("Usage: arp <target_ip>")
+					}
+				}
 			case "dhcpserver":
 				displayDHCPServer()
 				save()

--- a/connrouter.go
+++ b/connrouter.go
@@ -1,6 +1,6 @@
 /*
 File:		connrouter.go
-Author: 	https://bitbucket.org/vincebel
+Author: 	https://github.com/vincebel7
 Purpose:	Handles connection and interface for router
 */
 

--- a/datagram.go
+++ b/datagram.go
@@ -11,14 +11,47 @@ import (
 	"fmt"
 )
 
-/** L4 structs and functions **/
+/** Datagram Structs **/
 type UDPSegment struct {
-	SrcPort int    `json:"src_port"`
-	DstPort int    `json:"dst_port"`
-	Data    string `json:"data"`
+	SrcPort  int    `json:"src_port"`
+	DstPort  int    `json:"dst_port"`
+	Length   string `json:"length"`
+	Checksum string `json:"checksum"`
+	Data     string `json:"data"`
 }
 
-func constructUDPSegment(data string, srcPort int, dstPort int) json.RawMessage {
+type IPv4Packet struct {
+	Header json.RawMessage `json:"header"`
+	Data   json.RawMessage `json:"data"`
+}
+
+type PacketHeader struct {
+	Protocol int    `json:"protocol"`
+	SrcIP    string `json:"src_ip"`
+	DstIP    string `json:"dst_ip"`
+}
+
+type ICMPPacket struct {
+	ControlType int             `json:"control_type"` // 8 for Request, 0 for Reply
+	Data        json.RawMessage `json:"data"`
+}
+
+type Frame struct {
+	SrcMAC    string          `json:"src_mac"`
+	DstMAC    string          `json:"dst_mac"`
+	EtherType string          `json:"ether_type"`
+	Data      json.RawMessage `json:"data"`
+}
+
+type ArpMessage struct {
+	Opcode    int    `json:"opcode"` // 1 for request, 2 for reply
+	SenderMAC string `json:"sender_mac"`
+	SenderIP  string `json:"sender_ip"`
+	TargetMAC string `json:"target_mac"`
+	TargetIP  string `json:"target_ip"`
+}
+
+func constructUDPSegment(srcPort int, dstPort int, data string) json.RawMessage {
 	segment := UDPSegment{
 		SrcPort: srcPort,
 		DstPort: dstPort,
@@ -27,35 +60,6 @@ func constructUDPSegment(data string, srcPort int, dstPort int) json.RawMessage 
 
 	segmentBytes, _ := json.Marshal(segment)
 	return segmentBytes
-}
-
-// Turns segment into an accessible object
-func readUDPSegment(rawUDPSegment string) UDPSegment {
-	var segment UDPSegment
-	err := json.Unmarshal([]byte(rawUDPSegment), &segment)
-	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
-		return UDPSegment{}
-	}
-
-	return segment
-}
-
-/** L3 structs and functions **/
-type PacketHeader struct {
-	Protocol int    `json:"protocol"`
-	SrcIP    string `json:"src_ip"`
-	DstIP    string `json:"dst_ip"`
-}
-
-type IPv4Packet struct {
-	Header json.RawMessage `json:"header"`
-	Data   json.RawMessage `json:"data"`
-}
-
-type ICMPPacket struct {
-	ControlType int             `json:"control_type"` // 8 for Request, 0 for Reply
-	Data        json.RawMessage `json:"data"`
 }
 
 func constructIPv4Packet(srcIP string, dstIP string, protocolName string, data json.RawMessage) json.RawMessage {
@@ -84,57 +88,7 @@ func constructIPv4Packet(srcIP string, dstIP string, protocolName string, data j
 	return json.RawMessage(packetBytes)
 }
 
-// Turns packet into an accessible object
-func readIPv4Packet(rawPacket string) IPv4Packet {
-	var packet IPv4Packet
-	err := json.Unmarshal([]byte(rawPacket), &packet)
-	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
-		return IPv4Packet{}
-	}
-
-	return packet
-}
-
-func readIPv4PacketHeader(rawPacketHeader string) PacketHeader {
-	var packetHeader PacketHeader
-	err := json.Unmarshal([]byte(rawPacketHeader), &packetHeader)
-	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
-		return PacketHeader{}
-	}
-
-	return packetHeader
-}
-
-func readICMPPacket(rawPacket string) ICMPPacket {
-	var packet ICMPPacket
-	err := json.Unmarshal([]byte(rawPacket), &packet)
-	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
-		return ICMPPacket{}
-	}
-
-	return packet
-}
-
-/** L2 structs and functions **/
-type Frame struct {
-	SrcMAC    string          `json:"src_mac"`
-	DstMAC    string          `json:"dst_mac"`
-	EtherType string          `json:"ether_type"`
-	Data      json.RawMessage `json:"data"`
-}
-
-type ArpMessage struct {
-	Opcode    int    `json:"opcode"` // 1 for request, 2 for reply
-	SenderMAC string `json:"sender_mac"`
-	SenderIP  string `json:"sender_ip"`
-	TargetMAC string `json:"target_mac"`
-	TargetIP  string `json:"target_ip"`
-}
-
-func constructFrame(data string, srcMAC string, dstMAC string, protocolName string) string {
+func constructFrame(srcMAC string, dstMAC string, protocolName string, data json.RawMessage) string {
 	etherType := "0x0"
 	switch protocolName {
 	case "IPv4":
@@ -147,17 +101,63 @@ func constructFrame(data string, srcMAC string, dstMAC string, protocolName stri
 		SrcMAC:    srcMAC,
 		DstMAC:    dstMAC,
 		EtherType: etherType,
-		Data:      json.RawMessage(data),
+		Data:      data,
 	}
 
 	frameBytes, _ := json.Marshal(frame)
 	return string(frameBytes)
 }
 
+// Turns segment into an accessible object
+func readUDPSegment(rawUDPSegment json.RawMessage) UDPSegment {
+	var segment UDPSegment
+	err := json.Unmarshal(rawUDPSegment, &segment)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return UDPSegment{}
+	}
+
+	return segment
+}
+
+// Turns packet into an accessible object
+func readIPv4Packet(rawPacket json.RawMessage) IPv4Packet {
+	var packet IPv4Packet
+	err := json.Unmarshal(rawPacket, &packet)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return IPv4Packet{}
+	}
+
+	return packet
+}
+
+func readIPv4PacketHeader(rawPacketHeader json.RawMessage) PacketHeader {
+	var packetHeader PacketHeader
+	err := json.Unmarshal(rawPacketHeader, &packetHeader)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return PacketHeader{}
+	}
+
+	return packetHeader
+}
+
+func readICMPPacket(rawPacket json.RawMessage) ICMPPacket {
+	var packet ICMPPacket
+	err := json.Unmarshal(rawPacket, &packet)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return ICMPPacket{}
+	}
+
+	return packet
+}
+
 // Turns frame into an accessible object
-func readFrame(rawFrame string) Frame {
+func readFrame(rawFrame json.RawMessage) Frame {
 	var frame Frame
-	err := json.Unmarshal([]byte(rawFrame), &frame)
+	err := json.Unmarshal(rawFrame, &frame)
 	if err != nil {
 		fmt.Println("Error unmarshalling JSON:", err)
 		return Frame{}
@@ -167,9 +167,9 @@ func readFrame(rawFrame string) Frame {
 }
 
 // Turns ArpMessage into an accessible object
-func readArpMessage(rawPacket string) ArpMessage {
+func readArpMessage(rawPacket json.RawMessage) ArpMessage {
 	var arpMessage ArpMessage
-	err := json.Unmarshal([]byte(rawPacket), &arpMessage)
+	err := json.Unmarshal(rawPacket, &arpMessage)
 	if err != nil {
 		fmt.Println("Error unmarshalling JSON:", err)
 		return ArpMessage{}

--- a/datagram.go
+++ b/datagram.go
@@ -6,56 +6,174 @@ Purpose:	Datagram structs, and associated functions
 
 package main
 
-type Segment struct {
-	Protocol string
-	SrcPort  int
-	DstPort  int
-	Data     string
+import (
+	"encoding/json"
+	"fmt"
+)
+
+/** L4 structs and functions **/
+type UDPSegment struct {
+	SrcPort int    `json:"src_port"`
+	DstPort int    `json:"dst_port"`
+	Data    string `json:"data"`
 }
 
-type Packet struct {
-	SrcIP string
-	DstIP string
-	Data  Segment
-}
-
-type Frame struct {
-	SrcMAC string
-	DstMAC string
-	Data   Packet
-}
-
-func constructSegment(data string) Segment {
-	srcport := 7
-	dstport := 7
-	protocol := "UDP"
-
-	s := Segment{
-		Protocol: protocol,
-		SrcPort:  srcport,
-		DstPort:  dstport,
-		Data:     data,
+func constructUDPSegment(data string, srcPort int, dstPort int) json.RawMessage {
+	segment := UDPSegment{
+		SrcPort: srcPort,
+		DstPort: dstPort,
+		Data:    data,
 	}
 
-	return s
+	segmentBytes, _ := json.Marshal(segment)
+	return segmentBytes
 }
 
-func constructPacket(srcIP string, dstIP string, data Segment) Packet {
-	p := Packet{
-		SrcIP: srcIP,
-		DstIP: dstIP,
-		Data:  data,
+// Turns segment into an accessible object
+func readUDPSegment(rawUDPSegment string) UDPSegment {
+	var segment UDPSegment
+	err := json.Unmarshal([]byte(rawUDPSegment), &segment)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return UDPSegment{}
 	}
 
-	return p
+	return segment
 }
 
-func constructFrame(data Packet, srcMAC string, dstMAC string) Frame {
-	f := Frame{
-		SrcMAC: srcMAC,
-		DstMAC: dstMAC,
+/** L3 structs and functions **/
+type PacketHeader struct {
+	Protocol int    `json:"protocol"`
+	SrcIP    string `json:"src_ip"`
+	DstIP    string `json:"dst_ip"`
+}
+
+type IPv4Packet struct {
+	Header json.RawMessage `json:"header"`
+	Data   json.RawMessage `json:"data"`
+}
+
+type ICMPPacket struct {
+	ControlType int             `json:"control_type"` // 8 for Request, 0 for Reply
+	Data        json.RawMessage `json:"data"`
+}
+
+func constructIPv4Packet(srcIP string, dstIP string, protocolName string, data json.RawMessage) json.RawMessage {
+	protocolNumber := -1
+	switch protocolName {
+	case "UDP":
+		protocolNumber = 17
+	case "ICMP":
+		protocolNumber = 1
+	}
+
+	header := PacketHeader{
+		Protocol: protocolNumber,
+		SrcIP:    srcIP,
+		DstIP:    dstIP,
+	}
+
+	packetHeaderBytes, _ := json.Marshal(header)
+
+	packet := IPv4Packet{
+		Header: json.RawMessage(packetHeaderBytes),
 		Data:   data,
 	}
 
-	return f
+	packetBytes, _ := json.Marshal(packet)
+	return json.RawMessage(packetBytes)
+}
+
+// Turns packet into an accessible object
+func readIPv4Packet(rawPacket string) IPv4Packet {
+	var packet IPv4Packet
+	err := json.Unmarshal([]byte(rawPacket), &packet)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return IPv4Packet{}
+	}
+
+	return packet
+}
+
+func readIPv4PacketHeader(rawPacketHeader string) PacketHeader {
+	var packetHeader PacketHeader
+	err := json.Unmarshal([]byte(rawPacketHeader), &packetHeader)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return PacketHeader{}
+	}
+
+	return packetHeader
+}
+
+func readICMPPacket(rawPacket string) ICMPPacket {
+	var packet ICMPPacket
+	err := json.Unmarshal([]byte(rawPacket), &packet)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return ICMPPacket{}
+	}
+
+	return packet
+}
+
+/** L2 structs and functions **/
+type Frame struct {
+	SrcMAC    string          `json:"src_mac"`
+	DstMAC    string          `json:"dst_mac"`
+	EtherType string          `json:"ether_type"`
+	Data      json.RawMessage `json:"data"`
+}
+
+type ArpMessage struct {
+	Opcode    int    `json:"opcode"` // 1 for request, 2 for reply
+	SenderMAC string `json:"sender_mac"`
+	SenderIP  string `json:"sender_ip"`
+	TargetMAC string `json:"target_mac"`
+	TargetIP  string `json:"target_ip"`
+}
+
+func constructFrame(data string, srcMAC string, dstMAC string, protocolName string) string {
+	etherType := "0x0"
+	switch protocolName {
+	case "IPv4":
+		etherType = "0x0800"
+	case "ARP":
+		etherType = "0x0806"
+	}
+
+	frame := Frame{
+		SrcMAC:    srcMAC,
+		DstMAC:    dstMAC,
+		EtherType: etherType,
+		Data:      json.RawMessage(data),
+	}
+
+	frameBytes, _ := json.Marshal(frame)
+	return string(frameBytes)
+}
+
+// Turns frame into an accessible object
+func readFrame(rawFrame string) Frame {
+	var frame Frame
+	err := json.Unmarshal([]byte(rawFrame), &frame)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return Frame{}
+	}
+
+	return frame
+}
+
+// Turns ArpMessage into an accessible object
+func readArpMessage(rawPacket string) ArpMessage {
+	var arpMessage ArpMessage
+	err := json.Unmarshal([]byte(rawPacket), &arpMessage)
+	if err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return ArpMessage{}
+	}
+
+	return arpMessage
 }

--- a/datagram.go
+++ b/datagram.go
@@ -88,7 +88,7 @@ func constructIPv4Packet(srcIP string, dstIP string, protocolName string, data j
 	return json.RawMessage(packetBytes)
 }
 
-func constructFrame(srcMAC string, dstMAC string, protocolName string, data json.RawMessage) string {
+func constructFrame(srcMAC string, dstMAC string, protocolName string, data json.RawMessage) json.RawMessage {
 	etherType := "0x0"
 	switch protocolName {
 	case "IPv4":
@@ -105,7 +105,7 @@ func constructFrame(srcMAC string, dstMAC string, protocolName string, data json
 	}
 
 	frameBytes, _ := json.Marshal(frame)
-	return string(frameBytes)
+	return frameBytes
 }
 
 // Turns segment into an accessible object

--- a/datagram.go
+++ b/datagram.go
@@ -44,11 +44,15 @@ type Frame struct {
 }
 
 type ArpMessage struct {
-	Opcode    int    `json:"opcode"` // 1 for request, 2 for reply
-	SenderMAC string `json:"sender_mac"`
-	SenderIP  string `json:"sender_ip"`
-	TargetMAC string `json:"target_mac"`
-	TargetIP  string `json:"target_ip"`
+	HTYPE     int    `json:"HTYPE"`
+	PTYPE     string `json:"PTYPE"`
+	HLEN      int    `json:"HLEN"`
+	PLEN      int    `json:"PLEN"`
+	Opcode    int    `json:"OPER"` // 1 for request, 2 for reply
+	SenderMAC string `json:"SHA"`
+	SenderIP  string `json:"SPA"`
+	TargetMAC string `json:"THA"`
+	TargetIP  string `json:"TPA"`
 }
 
 func constructUDPSegment(srcPort int, dstPort int, data string) json.RawMessage {

--- a/datagram.go
+++ b/datagram.go
@@ -1,6 +1,6 @@
 /*
 File:		datagram.go
-Author: 	https://bitbucket.org/vincebel
+Author: 	https://github.com/vincebel7
 Purpose:	Datagram structs, and associated functions
 */
 
@@ -31,8 +31,12 @@ type PacketHeader struct {
 	DstIP    string `json:"dst_ip"`
 }
 
-type ICMPPacket struct {
+type ICMPEchoPacket struct {
 	ControlType int             `json:"control_type"` // 8 for Request, 0 for Reply
+	ControlCode int             `json:"control_code"` // Often 0
+	Checksum    string          `json:"checksum"`
+	Identifier  int             `json:"identifier"`
+	SeqNumber   int             `json:"seq"`
 	Data        json.RawMessage `json:"data"`
 }
 
@@ -117,7 +121,7 @@ func readUDPSegment(rawUDPSegment json.RawMessage) UDPSegment {
 	var segment UDPSegment
 	err := json.Unmarshal(rawUDPSegment, &segment)
 	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
+		fmt.Println("[UDP] Error unmarshalling JSON:", err)
 		return UDPSegment{}
 	}
 
@@ -129,7 +133,7 @@ func readIPv4Packet(rawPacket json.RawMessage) IPv4Packet {
 	var packet IPv4Packet
 	err := json.Unmarshal(rawPacket, &packet)
 	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
+		fmt.Println("[IPv4 Packet] Error unmarshalling JSON:", err)
 		return IPv4Packet{}
 	}
 
@@ -140,19 +144,19 @@ func readIPv4PacketHeader(rawPacketHeader json.RawMessage) PacketHeader {
 	var packetHeader PacketHeader
 	err := json.Unmarshal(rawPacketHeader, &packetHeader)
 	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
+		fmt.Println("[IPv4 Header] Error unmarshalling JSON:", err)
 		return PacketHeader{}
 	}
 
 	return packetHeader
 }
 
-func readICMPPacket(rawPacket json.RawMessage) ICMPPacket {
-	var packet ICMPPacket
+func readICMPEchoPacket(rawPacket json.RawMessage) ICMPEchoPacket {
+	var packet ICMPEchoPacket
 	err := json.Unmarshal(rawPacket, &packet)
 	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
-		return ICMPPacket{}
+		fmt.Println("[ICMP Packet] Error unmarshalling JSON:", err)
+		return ICMPEchoPacket{}
 	}
 
 	return packet
@@ -163,7 +167,7 @@ func readFrame(rawFrame json.RawMessage) Frame {
 	var frame Frame
 	err := json.Unmarshal(rawFrame, &frame)
 	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
+		fmt.Println("[Frame] Error unmarshalling JSON:", err)
 		return Frame{}
 	}
 
@@ -171,11 +175,11 @@ func readFrame(rawFrame json.RawMessage) Frame {
 }
 
 // Turns ArpMessage into an accessible object
-func readArpMessage(rawPacket json.RawMessage) ArpMessage {
+func readArpMessage(rawMessage json.RawMessage) ArpMessage {
 	var arpMessage ArpMessage
-	err := json.Unmarshal(rawPacket, &arpMessage)
+	err := json.Unmarshal(rawMessage, &arpMessage)
 	if err != nil {
-		fmt.Println("Error unmarshalling JSON:", err)
+		fmt.Println("[ARP] Error unmarshalling JSON:", err)
 		return ArpMessage{}
 	}
 

--- a/debug.go
+++ b/debug.go
@@ -15,7 +15,7 @@ import (
 0 - No debugging
 1 - Errors
 2 - General network traffic
-3 - All network traffic
+3 - All network traffic and warnings
 4 - Garbage
 */
 
@@ -60,22 +60,15 @@ func debug(level int, generatingFunc string, generatingID string, message string
 	}
 }
 
-func inspectFrame(f Frame) {
-	p := f.Data
-	s := p.Data
+func inspectFrame(frame Frame) {
+	frameData := frame.Data
 
 	fmt.Printf("\n ========== FRAME ========== \n")
-	fmt.Printf("Source MAC:\t%s\n", f.SrcMAC)
-	fmt.Printf("Dest MAC:\t%s\n", f.DstMAC)
+	fmt.Printf("Source MAC:\t%s\n", frame.SrcMAC)
+	fmt.Printf("Dest MAC:\t%s\n", frame.DstMAC)
 
-	fmt.Printf("\n ========== PACKET ========== \n")
-	fmt.Printf("Source IP:\t%s\n", p.SrcIP)
-	fmt.Printf("Dest IP:\t%s\n", p.DstIP)
-
-	fmt.Printf("\n ========== SEGMENT ========== \n")
-	fmt.Printf("Protocol: %s\n", s.Protocol)
-	fmt.Printf("Source port: %d, Destination port: %d\n", s.SrcPort, s.DstPort)
-	fmt.Printf("Data: %s\n", s.Data)
+	fmt.Printf("\n ========== DATA ========== \n")
+	fmt.Printf(string(frameData))
 
 	fmt.Printf("\n")
 }

--- a/debug.go
+++ b/debug.go
@@ -1,6 +1,6 @@
 /*
-File:		debug.co
-Author: 	https://bitbucket.org/vincebel
+File:		debug.go
+Author: 	https://github.com/vincebel7
 Purpose:	Functions related to debugging and testing
 */
 

--- a/debug.go
+++ b/debug.go
@@ -56,7 +56,9 @@ func debug(level int, generatingFunc string, generatingID string, message string
 				hostname = generatingID
 			}
 		}
+		//fmt.Printf("\n[%s] (%s), %s\n", hostname, generatingFunc, message)
 		fmt.Printf("\n[%s] %s\n", hostname, message)
+
 	}
 }
 
@@ -68,7 +70,7 @@ func inspectFrame(frame Frame) {
 	fmt.Printf("Dest MAC:\t%s\n", frame.DstMAC)
 
 	fmt.Printf("\n ========== DATA ========== \n")
-	fmt.Printf(string(frameData))
+	fmt.Print(string(frameData))
 
 	fmt.Printf("\n")
 }

--- a/display.go
+++ b/display.go
@@ -58,7 +58,7 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 	// ROUTER
 	if rootType == "router" {
 		if rootHostname != "" {
-			drawRouter(snet.Router.ID)
+			drawRouter()
 		}
 
 		for i := range snet.Router.VSwitch.Ports {
@@ -75,7 +75,7 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 	}
 }
 
-func drawRouter(id string) {
+func drawRouter() {
 	space1 := 13 - len(snet.Router.Hostname)
 	space2 := 14 - len(snet.Router.Gateway.String())
 	space3 := 16 - len(snet.Router.Model)

--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"strconv"
 	"time"
 )
 
@@ -23,6 +24,20 @@ func idgen(n int) string {
 	}
 
 	return string(id)
+}
+
+func idgen_int(n int) int {
+	rand.Seed(time.Now().UnixNano())
+
+	firstDigit := rand.Intn(9) + 1
+	numberStr := strconv.Itoa(firstDigit)
+	for i := 1; i < n; i++ {
+		digit := rand.Intn(10)
+		numberStr += strconv.Itoa(digit)
+	}
+	result, _ := strconv.Atoi(numberStr)
+
+	return result
 }
 
 func macgen() string {

--- a/helpers.go
+++ b/helpers.go
@@ -9,8 +9,8 @@ package main
 import (
 	"fmt"
 	"math/rand"
-	"time"
 	"net"
+	"time"
 )
 
 func idgen(n int) string {

--- a/host.go
+++ b/host.go
@@ -8,8 +8,8 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"net"
+	"strings"
 )
 
 type Host struct {
@@ -81,4 +81,12 @@ func delHost(hostname string) {
 		}
 	}
 	fmt.Printf("\nHost %s was not deleted.\n", hostname)
+}
+
+func ipclear(id string) {
+	index := getHostIndexFromID(id)
+	snet.Hosts[index].IPAddr = nil
+	snet.Hosts[index].SubnetMask = ""
+	snet.Hosts[index].DefaultGateway = nil
+	fmt.Println("Network configuration cleared")
 }

--- a/listener.go
+++ b/listener.go
@@ -6,12 +6,12 @@ Purpose:	Listener for network and all devices
 
 package main
 
-var channels = map[string]chan Frame{} // the physical link
-var internal = map[string]chan Frame{} // for internal device communication
+var channels = make(map[string]chan string) // the physical link
+var internal = map[string]chan Frame{}      // for internal device communication
 var actionsync = map[string]chan int{}
 
 func Listener() {
-	channels["FFFFFFFF"] = make(chan Frame)
+	channels["FFFFFFFF"] = make(chan string)
 	go broadcastlisten()
 
 	generateRouterChannels()
@@ -25,9 +25,27 @@ func Listener() {
 	}
 }
 
+func generateHostChannels(i int) {
+	channels[snet.Hosts[i].ID] = make(chan string)
+	internal[snet.Hosts[i].ID] = make(chan Frame)
+	actionsync[snet.Hosts[i].ID] = make(chan int)
+
+	go hostlisten(snet.Hosts[i].ID)
+}
+
+func generateSwitchChannels(i int) {
+	for j := 0; j < getActivePorts(snet.Switches[j]); j++ {
+		channels[snet.Switches[i].PortIDs[j]] = make(chan string)
+		internal[snet.Switches[i].PortIDs[j]] = make(chan Frame)
+		actionsync[snet.Switches[i].PortIDs[j]] = make(chan int)
+
+		go switchportlisten(snet.Switches[i].PortIDs[j])
+	}
+}
+
 func generateRouterChannels() {
 	if snet.Router.Hostname != "" {
-		channels[snet.Router.ID] = make(chan Frame)
+		channels[snet.Router.ID] = make(chan string)
 		internal[snet.Router.ID] = make(chan Frame)
 		go routerlisten()
 
@@ -35,7 +53,7 @@ func generateRouterChannels() {
 		//channels[snet.Router.VSwitch.ID] = make(chan Frame)
 		//internal[snet.Router.VSwitch.ID] = make(chan Frame)
 		for i := 0; i < getActivePorts(snet.Router.VSwitch); i++ {
-			channels[snet.Router.VSwitch.PortIDs[i]] = make(chan Frame)
+			channels[snet.Router.VSwitch.PortIDs[i]] = make(chan string)
 			internal[snet.Router.VSwitch.PortIDs[i]] = make(chan Frame)
 			actionsync[snet.Router.ID] = make(chan int)
 
@@ -44,32 +62,15 @@ func generateRouterChannels() {
 	}
 }
 
-func generateSwitchChannels(i int) {
-	for j := 0; j < getActivePorts(snet.Switches[j]); j++ {
-		channels[snet.Switches[i].PortIDs[j]] = make(chan Frame)
-		internal[snet.Switches[i].PortIDs[j]] = make(chan Frame)
-		actionsync[snet.Switches[i].PortIDs[j]] = make(chan int)
-
-		go switchportlisten(snet.Switches[i].PortIDs[j])
-	}
-}
-
-func generateHostChannels(i int) {
-	channels[snet.Hosts[i].ID] = make(chan Frame)
-	internal[snet.Hosts[i].ID] = make(chan Frame)
-	actionsync[snet.Hosts[i].ID] = make(chan int)
-
-	go hostlisten(snet.Hosts[i].ID)
-}
-
 func broadcastlisten() { //Listens for broadcast frames on FF.. and broadcasts
 	for {
-		frame := <-channels["FFFFFFFF"]
+		frameString := <-channels["FFFFFFFF"]
 		debug(4, "broadcastlisten", "Listener", "detected broadcast")
-		go routeractionhandler(frame)
+
+		go actionHandler(frameString, snet.Router.ID)
 
 		for i := range snet.Hosts {
-			go hostactionhandler(frame, snet.Hosts[i].ID)
+			go actionHandler(frameString, snet.Hosts[i].ID)
 		}
 	}
 }
@@ -78,132 +79,142 @@ func hostlisten(id string) {
 	listenSync <- id //synchronizing with client.go
 
 	for {
-		frame := <-channels[id]
-		debug(4, "hostlisten", id, "Received frame")
-		go hostactionhandler(frame, id)
+		frameString := <-channels[id]
+		debug(4, "hostlisten", id, "Received unicast frame")
+
+		go actionHandler(frameString, id)
 	}
 }
 
-func hostactionhandler(frame Frame, id string) {
-	debug(4, "hostactionhandler", id, "My packet")
-	data := frame.Data.Data.Data
-	if data == "ping!" {
-		debug(4, "hostactionhandler", id, "ping received")
-		srcid := id
-		dstIP := frame.Data.SrcIP
-		pong(srcid, dstIP, frame)
+func routerlisten() {
+	for {
+		frameString := <-channels[snet.Router.ID]
+		debug(4, "routerlisten", snet.Router.ID, "Received unicast frame")
+		go actionHandler(frameString, snet.Router.ID)
 	}
+}
 
-	if data == "pong!" {
-		internal[id] <- frame
-	}
+// TODO eventually break this down into functions so it isn't so nested
+func actionHandler(frameString string, id string) {
+	debug(4, "actionHandler", id, "My packet")
 
-	if len(data) > 7 {
-		if data[0:8] == "ARPREPLY" {
-			debug(3, "hostactionhandler", id, "ARPREPLY received")
-			internal[id] <- frame
+	frame := readFrame(frameString)
+
+	switch frame.EtherType {
+	case "0x0806": // ARP
+		arpMessage := readArpMessage(string(frame.Data))
+		if arpMessage.Opcode == 2 {
+			debug(3, "actionHandler", id, "ARPREPLY received")
+
+			if snet.Router.ID == id {
+				if arpMessage.TargetIP == snet.Router.Gateway.String() {
+					internal[id] <- frame
+				} else {
+					debug(4, "actionhandler", id, "I'm the router. Not sure why i got this ARPREPLY not involving me.")
+				}
+			} else {
+				if arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String() {
+					internal[id] <- frame
+				} else {
+					debug(4, "actionhandler", id, "I'm an uninvolved host. Not sure why i got this ARPREPLY not involving me.")
+				}
+			}
 		}
 
-	}
+		if arpMessage.Opcode == 1 {
+			debug(3, "actionHandler", id, "ARPREQUEST received")
 
-	if len(data) > 8 {
-		if data[0:9] == "DHCPOFFER" {
-			debug(2, "hostactionhandler", id, "DHCPOFFER received")
-			internal[id] <- frame
+			// Temporary fix until arp_reply is generalized.
+			if snet.Router.ID == id {
+				if arpMessage.TargetIP == snet.Router.Gateway.String() {
+					index := 0
+					arp_reply(index, "router", frame)
+				}
+			} else {
+				if arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String() {
+					arp_reply(getHostIndexFromID(id), "host", frame)
+				}
+			}
 		}
-	}
 
-	if len(data) > 9 {
-		if data[0:10] == "ARPREQUEST" {
-			debug(4, "hostactionhandler", id, "ARPREQUEST received")
-			arp_reply(getHostIndexFromID(id), "host", frame)
-		}
-	}
+	case "0x0800": // IPv4
+		packet := readIPv4Packet(string(frame.Data))
 
-	if len(data) > 17 {
-		if data[0:19] == "DHCPACKNOWLEDGEMENT" {
-			debug(2, "hostactionhandler", id, "DHCPACKNOWLEDGEMENT received")
-			internal[id] <- frame
+		switch readIPv4PacketHeader(string(packet.Header)).Protocol {
+		case 1: // ICMP
+			icmpPacket := readICMPPacket(string(packet.Data))
+			if icmpPacket.ControlType == 8 {
+				debug(3, "actionHandler", id, "Ping received")
+				pong(id, frame)
+			}
+
+			if icmpPacket.ControlType == 0 {
+				debug(3, "actionHandler", id, "Pong received")
+				internal[id] <- frame
+			}
+
+		case 17: // UDP
+			udpSegment := readUDPSegment(string(packet.Data))
+
+			switch udpSegment.DstPort {
+			case 67: // Server-bound messages
+				if snet.Router.ID != id { // Temporary validation
+					debug(4, "actionHandler", id, "DHCP server traffic received on host. Ignoring")
+					return
+				}
+
+				if string(udpSegment.Data) == "DHCPDISCOVER" { // TODO not sure if this []byte to string thing works.
+					debug(2, "actionHandler", id, "DHCPDISCOVER received")
+					dhcp_offer(frame)
+				}
+
+				if len(string(udpSegment.Data)) > 10 { // TODO not sure if this []byte to string thing works.
+					if string(udpSegment.Data)[0:11] == "DHCPREQUEST" { // TODO not sure if this []byte to string thing works.
+						debug(2, "actionHandler", id, "DHCPREQUEST received")
+						internal[id] <- frame
+					}
+				}
+
+			case 68: // Client-bound messages
+				if len(string(udpSegment.Data)) > 8 { // TODO not sure if this []byte to string thing works.
+					if string(udpSegment.Data)[0:9] == "DHCPOFFER" { // TODO not sure if this []byte to string thing works.
+						debug(2, "actionHandler", id, "DHCPOFFER received")
+						internal[id] <- frame
+					}
+				}
+
+				if len(string(udpSegment.Data)) > 17 { // TODO not sure if this []byte to string thing works.
+					if string(udpSegment.Data)[0:19] == "DHCPACKNOWLEDGEMENT" { // TODO not sure if this []byte to string thing works.
+						debug(2, "actionHandler", id, "DHCPACKNOWLEDGEMENT received")
+						internal[id] <- frame
+					}
+
+				}
+			}
 		}
 	}
 }
 
 func switchportlisten(id string) {
 	for {
-		frame := <-channels[id]
-		debug(4, "switchlisten", id, "Received frame")
+		frameBytes := <-channels[id]
+		debug(4, "switchlisten", id, "(Switch) Received unicast frame")
 
 		port := getSwitchportIDFromLink(id)
 
-		checkMACTable(frame.SrcMAC, id, port)
+		checkMACTable(readFrame(frameBytes).SrcMAC, id, port)
 
-		go switchportactionhandler(frame, id)
+		go switchportactionhandler(frameBytes, id)
 	}
 }
 
-func switchportactionhandler(frame Frame, id string) {
+func switchportactionhandler(frameBytes string, id string) {
 	debug(4, "switchportactionhandler", id, "My packet")
-	if frame.DstMAC == "FF:FF:FF:FF:FF:FF" {
-		channels["FFFFFFFF"] <- frame
+	if readFrame(frameBytes).DstMAC == "FF:FF:FF:FF:FF:FF" {
+		channels["FFFFFFFF"] <- frameBytes
 	} else if 1 == 2 { //TODO how to receive mgmt frames
 		//data := frame.Data.Data.Data
 	} else {
-		switchforward(frame, id)
-	}
-}
-
-func routerlisten() {
-	for {
-		frame := <-channels[snet.Router.ID]
-		debug(4, "routerlisten", snet.Router.ID, "Frame received")
-		go routeractionhandler(frame)
-	}
-}
-
-func routeractionhandler(frame Frame) {
-	if (frame.Data.DstIP == snet.Router.Gateway.String()) || (frame.DstMAC == "FF:FF:FF:FF:FF:FF") {
-		debug(4, "routeractionhandler", snet.Router.ID, "My packet")
-		data := frame.Data.Data.Data
-		srcid := snet.Router.ID
-		dstIP := frame.Data.SrcIP
-		if data == "ping!" {
-			debug(3, "routeractionhandler", snet.Router.ID, "ping received")
-			pong(srcid, dstIP, frame)
-		}
-		if data == "pong!" {
-			debug(3, "routeractionhandler", snet.Router.ID, "pong received")
-			internal[snet.Router.ID] <- frame
-		}
-
-		if len(data) > 7 {
-			if data[0:8] == "ARPREPLY" {
-				debug(3, "routeractionhandler", snet.Router.ID, "ARPREPLY received")
-				internal[snet.Router.ID] <- frame
-			}
-		}
-
-		if len(data) > 9 {
-			if data[0:10] == "ARPREQUEST" {
-				debug(3, "routeractionhandler", snet.Router.ID, "ARPREQUEST received")
-				index := 0
-				arp_reply(index, "router", frame)
-			}
-		}
-
-		if data == "DHCPDISCOVER" {
-			debug(2, "routeractionhandler", snet.Router.ID, "DHCPDISCOVER received")
-			dhcp_offer(frame)
-		}
-
-		if len(data) > 10 {
-			if data[0:11] == "DHCPREQUEST" {
-				debug(2, "routeractionhandler", snet.Router.ID, "DHCPREQUEST received")
-				internal[snet.Router.ID] <- frame
-			}
-		}
-
-	} else {
-		debug(1, "routeractionhandler", snet.Router.ID, "Error: Still expecting router to forward? (not vswitch)")
-		inspectFrame(frame)
+		switchforward(readFrame(frameBytes), id)
 	}
 }

--- a/listener.go
+++ b/listener.go
@@ -1,6 +1,6 @@
 /*
 File:		listener.go
-Author: 	https://bitbucket.org/vincebel
+Author: 	https://github.com/vincebel7
 Purpose:	Listener for network and all devices
 */
 

--- a/listener.go
+++ b/listener.go
@@ -119,7 +119,7 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 			amTarget := false
 			if (snet.Router.ID == id) && (arpMessage.TargetIP == snet.Router.Gateway.String()) {
 				amTarget = true
-			} else if arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String() {
+			} else if (snet.Router.ID != id) && (arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
 				amTarget = true
 			}
 
@@ -134,7 +134,7 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 			amTarget := false
 			if (snet.Router.ID == id) && (arpMessage.TargetIP == snet.Router.Gateway.String()) {
 				amTarget = true
-			} else if arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String() {
+			} else if (snet.Router.ID != id) && (arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
 				amTarget = true
 			}
 

--- a/network.go
+++ b/network.go
@@ -1,3 +1,9 @@
+/*
+File:		network.go
+Author: 	https://github.com/vincebel7
+Purpose: 	Network object
+*/
+
 package main
 
 import (

--- a/router.go
+++ b/router.go
@@ -9,20 +9,20 @@ package main
 import (
 	"fmt"
 	"math/big"
-	"strings"
 	"net"
+	"strings"
 
 	"github.com/vincebel7/ltdnet/iphelper"
 )
 
 type Router struct {
-	ID           string   `json:"id"`
-	Model        string   `json:"model"`
-	MACAddr      string   `json:"macaddr"` // LAN-facing interface
-	Hostname     string   `json:"hostname"`
-	Gateway      net.IP   `json:"gateway"`
-	VSwitch      Switch   `json:"vswitchid"`      // Virtual built-in switch to router
-	DHCPPool     DHCPPool `json:"dhcp_pool"`      // Instance of DHCPPool
+	ID       string   `json:"id"`
+	Model    string   `json:"model"`
+	MACAddr  string   `json:"macaddr"` // LAN-facing interface
+	Hostname string   `json:"hostname"`
+	Gateway  net.IP   `json:"gateway"`
+	VSwitch  Switch   `json:"vswitchid"` // Virtual built-in switch to router
+	DHCPPool DHCPPool `json:"dhcp_pool"` // Instance of DHCPPool
 }
 
 type DHCPPool struct {
@@ -116,7 +116,7 @@ func addRouter(routerHostname string, routerModel string) {
 	assignSwitchport(snet.Router.VSwitch, snet.Router.ID)
 }
 
-func delRouter(hostname string) {
+func delRouter() {
 	r := Router{}
 
 	r.ID = ""
@@ -157,6 +157,6 @@ func (router Router) GetDHCPPoolAddresses() []net.IP {
 	for i := new(big.Int).Set(startIPInt); i.Cmp(endIPInt) <= 0; i.Add(i, big.NewInt(1)) {
 		poolAddrs = append(poolAddrs, iphelper.BigIntToIP(i)) // Convert back to string IP
 	}
-	
+
 	return poolAddrs
 }

--- a/router.go
+++ b/router.go
@@ -1,6 +1,6 @@
 /*
 File:		router.go
-Author: 	https://bitbucket.org/vincebel
+Author: 	https://github.com/vincebel7
 Purpose:	Router-specific functions
 */
 
@@ -111,9 +111,9 @@ func addRouter(routerHostname string, routerModel string) {
 
 	snet.Router = r
 
-	generateRouterChannels()
-
 	assignSwitchport(snet.Router.VSwitch, snet.Router.ID)
+
+	generateRouterChannels()
 }
 
 func delRouter() {

--- a/switch.go
+++ b/switch.go
@@ -196,10 +196,10 @@ func assignSwitchport(sw Switch, id string) Switch {
 		}
 	}
 
-	channels[sw.PortIDs[portIndex]] = make(chan string)
+	channels[sw.PortIDs[portIndex]] = make(chan json.RawMessage)
 	internal[sw.PortIDs[portIndex]] = make(chan Frame)
-	debug(4, "generateRouterChannels", sw.PortIDs[portIndex], "listening for id")
-	go switchportlisten(sw.PortIDs[portIndex])
+	debug(4, "assignSwitchport", sw.PortIDs[portIndex], "listening for id")
+	go listenSwitchportChannel(sw.PortIDs[portIndex])
 
 	return sw
 }
@@ -234,8 +234,8 @@ func switchforward(frame Frame, id string) {
 		EtherType: frame.EtherType,
 		Data:      p,
 	}
-	fBytes, _ := json.Marshal(f)
-	channels[linkID] <- string(fBytes)
+	outFrame, _ := json.Marshal(f)
+	channels[linkID] <- outFrame
 }
 
 func freeSwitchport(link string) {

--- a/switch.go
+++ b/switch.go
@@ -1,6 +1,6 @@
 /*
 File:		switch.go
-Author: 	https://bitbucket.org/vincebel
+Author: 	https://github.com/vincebel7
 Purpose:	Switch-specific functions
 */
 
@@ -197,7 +197,6 @@ func assignSwitchport(sw Switch, id string) Switch {
 	}
 
 	channels[sw.PortIDs[portIndex]] = make(chan json.RawMessage)
-	internal[sw.PortIDs[portIndex]] = make(chan Frame)
 	debug(4, "assignSwitchport", sw.PortIDs[portIndex], "listening for id")
 	go listenSwitchportChannel(sw.PortIDs[portIndex])
 
@@ -212,7 +211,7 @@ func switchforward(frame Frame, id string) {
 	outboundPort := lookupMACTable(dstMAC, id)
 
 	if outboundPort == -1 { // No matching port for this MAC address was found in the MAC address table.
-		debug(3, "switchforward", id, "Warning: Not found in MAC table, using bypass") //TODO implement flooding
+		debug(4, "switchforward", id, "Warning: Not found in MAC table, using bypass") //TODO implement flooding
 		linkID = getIDfromMAC(dstMAC)
 	} else {
 		if isSwitchportID(snet.Router.VSwitch, id) {


### PR DESCRIPTION
Features/Improvements:
- Datagrams and protocol messages are now mostly structs, matching closely to real network protocol structure. 
- Sockets for internal application-level communication. Replaces single "internal" channel with a map of channels akin to network sockets.
- Rework debug levels to be more consistent
- Rework ARP and ping actions
- Feature: Can now manually ARP from command-line (helpful for debugging)

Bugfixes:
- Fix bug where program deadlocks on failed ping (was the result of failed ARP requests going unhandled)
- Fix ping sequencing on the event of failed pings
- Fix issue where router could sometimes not ping itself (solved with sockets)