### PR TITLE
v0.3 - Achievements, ARP tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 saves/user_saves/*.json
+saves/user_settings.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -108,3 +108,5 @@ Creating, saving, and loading JSON savefiles, creating a network, adding and lin
 ### v0.0 - July 17, 2019
 Basic interface
 
+## License
+This project is licensed under the terms of the GNU General Public License v3.0. See the [LICENSE](./LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ See README.md :)
 ## Version History
 What has been accomplished at each major.minor version
 
+### v0.3.0 - ? 2024
+User achievements, ARP table, switch MAC address tables, user preferences
+
 ### v0.2.11 - October 25, 2024
 Subnetting, DHCP + ping funcionality rework, generalize destination MAC finding
 

--- a/README.md
+++ b/README.md
@@ -3,82 +3,49 @@
 ### https://github.com/vincebel7/ltdnet
 
 
-A limited-functionality network simulator that serves as a practical application of goroutines, taking advantage of lightweight multi-threading for network traffic and device-listening.
-Includes fictional LAN appliances as well as simple implementations of essential TCP/IP protocols
+A little CLI-based network simulator for learning networking concepts, utilizing lightweight goroutines and channels for network traffic.
+Includes fictional network appliances and simple implementations of essential TCP/IP protocols.
 
 ## How to run
 1. Install Go (https://golang.org/doc/install)
 2. Clone this repository and enter the directory
 3. Make the run script executable, and execute it (./run.sh)
 
-## Using ltdnet
-First, create a network and pick a class (A, B, or C)
-Currently, each network can only have one router. It is best to start off by creating a router:
+## ltdnet Tutorial
+First, create a network and pick a network size (/24 is recommended to start)
+Currently, each network can only have one router. It is best to start off by creating the router:
 `add router router1`
 
-Next, you will want to create a host:
+Next, create a host:
 `add host host1`
 
-You can now take a look at your network by running a show command. The most comprehensive of these is:
+You can now look at your network by running a show command. The most comprehensive of these is:
 `show network overview`
 
 Once you have created a host, you can "plug in" the host to the router by *linking* them.
 `link host host1 router1`
 
-This will allow you to set your host's uplink to your router.
-
-Next, you will need to set the IP configuration for your host. There are two ways to do this: Statically, or dynamically through DHCP. Both ways require you to be in device control mode.
-When controlling a device, the commands are different from the root ltdnet menu. Run `help` to see all available device control commands.
-To enter device control mode, run:
-`control host <hostname>`
+Next, set the IP configuration for your host. There are two ways to do this: Statically, or dynamically through DHCP. Both ways require you to be in device control mode.
+When controlling a device, the commands are different from the main ltdnet menu. Run `help` to see all available device control commands.
+To enter device control mode for host1, run:
+`control host host1`
 
 If you wish to statically set your host's IP configuration, from device control mode run:
-`ipset host <hostname>`
-This will prompt you to set an IP address, subnet mask, and default gateway for your host. Remember to make sure you set the default gateway to the one your router is generated with.
+`ip set <address>`
+The program will pick a subnet mask and default gateway, then ask you to confirm the new IP configuration.
 
-To run DHCP to dynamically acquire an IP configuration, from device control mode simply run `dhcp`.
+To run DHCP to dynamically acquire an IP configuration, from device control mode simply run `dhcp`. As long as there are available addresses in the router's DHCP pool, your host should now have an IP configuration.
 
-As long as there are available addresses in the router's DHCP pool, your host should now have an IP configuration. To test this out, from the device control, try pinging your router:
+To test connectivity, try pinging your router (likely 192.168.0.1) from the device control:
 `ping <gateway>`
 
-I hope you find this program to be fun. Many more features are on their way, but the main focus right now is ironing out some of the remaining bugs in v0.1 and cleaning up some debugging code still in place.
+What now? You can start by reading the user manual from within the program with the `manual` command, or you can try to complete all the Achievements (`achievements` command).
 
-For any further questions, please email vince@vincebel.tech
+I hope you find this program to be fun. Many more features are on their way, but the main focus right now is ironing out some of the remaining bugs in v0.x.
 
-## Files
+For any further questions, please email vincebel@protonmail.com
 
-### client.go
-Basic menu operations, data structures
-
-### conn.go
-Handles device interfaces
-
-### listener.go
-Listens for incoming traffic and handles actions accordingly
-
-### actions.go
-All "program" functions run on devices such as ping, DHCP, etc.
-
-### router.go
-Router-specific functions and structs
-
-### switch.go
-Switch-specific functions and structs
-
-### host.go
-Host-specific functions and structs
-
-### network.go
-Network-specific functions and structs
-
-### helpers.go
-Helper functions for common operations
-
-### debug.go
-Functions for debugging and testing
-
-### display.go
-Functions for drawing ASCII network diagrams and displaying network info
+## Scripts
 
 ### run.sh
 Simple run script to run *.go
@@ -86,17 +53,18 @@ Simple run script to run *.go
 ### wipesaves.sh
 Clears the /saves directory
 
-### README.md
-See README.md :)
-
 ## Known bugs
-- Save files may break with newer versions (Future fix: Version files, no breaking changes in minor versions)
+- Save files may break with newer versions (Future fix: No breaking changes in minor versions)
+
+- Resetting user settings puts program into errored state. (Temporary fix: Restart program)
+
+- Hosts ARP for their own MAC address (Low priority)
 
 ## Version History
-What has been accomplished at each major.minor version
+What has been accomplished at each version
 
 ### v0.3.0 - ? 2024
-User achievements, ARP table, switch MAC address tables, user preferences
+User Achievements, ARP table, switch MAC address tables, user preferences
 
 ### v0.2.11 - October 25, 2024
 Subnetting, DHCP + ping funcionality rework, generalize destination MAC finding

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Clears the /saves directory
 ## Version History
 What has been accomplished at each version
 
-### v0.3.0 - ? 2024
+### v0.3.0 - October 26, 2024
 User Achievements, ARP table, switch MAC address tables, user preferences
 
 ### v0.2.11 - October 25, 2024

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ See README.md :)
 ## Version History
 What has been accomplished at each major.minor version
 
+### v0.2.11 - October 25, 2024
+Subnetting, DHCP + ping funcionality rework, generalize destination MAC finding
+
 ### v0.2.10 - September 30, 2024
 Structs for messages and datagrams, sockets for internal application-layer communication
 

--- a/USER-MANUAL
+++ b/USER-MANUAL
@@ -1,6 +1,6 @@
 ===============
 ltdnet manual
-v0.2.11
+v0.3.0
 ===============
 
 Welcome to ltdnet! Using this program, you can simulate a LAN (Local Area Network) with virtual computers, switches, and routers. ltdnet features fictional device models, such as the ProBox, a state-of-the-art PC workstation, and the Bobcat 100, a sturdy small business router (with no recurring license fees!).
@@ -49,3 +49,5 @@ Now you're connected!
 
 ## Networking
 Instructions coming soon. Why not use the "help" command to see how to connect to your new PC?
+
+Also, if you're a completionist or just need something to do, ltdnet has Achievements. Try "achievements" for more info.

--- a/achievements.go
+++ b/achievements.go
@@ -13,9 +13,10 @@ package main
 import "fmt"
 
 type Achievement struct {
-	ID         int    `json:"id"`
-	Name       string `json:"name"`
-	ProgramVer string `json:"program_ver"`
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ProgramVer  string `json:"program_ver"`
 }
 
 var AchievementCatalog = make(map[int]Achievement)
@@ -26,21 +27,23 @@ var UNITED_PINGDOM = 2
 
 func buildAchievementCatalog() {
 	achievement := Achievement{
-		ID:   ROUTINE_BUSINESS,
-		Name: "Route-ine Business",
+		ID:          ROUTINE_BUSINESS,
+		Name:        "Route-ine Business",
+		Description: "Add a router to your network.",
 	}
 	AchievementCatalog[ROUTINE_BUSINESS] = achievement
 
 	achievement = Achievement{
-		ID:   UNITED_PINGDOM,
-		Name: "United Pingdom",
+		ID:          UNITED_PINGDOM,
+		Name:        "United Pingdom",
+		Description: "Successfully ping from one device to another.",
 	}
 	AchievementCatalog[UNITED_PINGDOM] = achievement
 }
 
 func displayAchievements() {
 	fmt.Printf("ACHIEVEMENTS:\n")
-	fmt.Printf("#\tAchievement Name\t\tUnlocked\n")
+	fmt.Printf("#\tName\t\t\t\tDescription\t\t\t\t\tUnlocked\n")
 
 	keys := make([]int, 1, len(AchievementCatalog))
 	for k := range AchievementCatalog {
@@ -58,7 +61,7 @@ func displayAchievements() {
 			unlockedChar = "Y"
 		}
 
-		fmt.Printf("%d\t%s\t%s\n", AchievementCatalog[i].ID, PadRight(AchievementCatalog[i].Name, 25), unlockedChar)
+		fmt.Printf("%d\t%s\t%s\t%s\n", AchievementCatalog[i].ID, PadRight(AchievementCatalog[i].Name, 25), PadRight(AchievementCatalog[i].Description, 45), unlockedChar)
 	}
 }
 

--- a/achievements.go
+++ b/achievements.go
@@ -86,7 +86,7 @@ func achievementCheck() {
 	}
 
 	// Test state-based Achievements
-	achievementTester(ROUTINE_BUSINESS)
+	//achievementTester()
 }
 
 // Kicks off tests for incomplete Achievements
@@ -109,16 +109,9 @@ func achievementTester(achievementID int) {
 
 // Achievement 1: Create a router
 func achievement1Test() {
-	achievementComplete := false
-
-	if snet.Router.ID != "" {
-		achievementComplete = true
-	}
-
-	if achievementComplete {
-		achievement := AchievementCatalog[ROUTINE_BUSINESS]
-		achievementAward(achievement)
-	}
+	// If this function is called, the achievement is already complete (action-based)
+	achievement := AchievementCatalog[ROUTINE_BUSINESS]
+	achievementAward(achievement)
 }
 
 // Achievement 2: Successful ping

--- a/achievements.go
+++ b/achievements.go
@@ -3,7 +3,7 @@ File:		achievements.go
 Author: 	https://github.com/vincebel7
 Purpose:	Achievements
 
-Note: There are two types of achievements: State-based, and action-based.
+Note: There are two types of Achievements: State-based, and action-based.
 State-based: Achievements based on network state which can be checked regularly (network has a router)
 Action-based: Achievements given when a particular action occurs (successful ping)
 */
@@ -21,9 +21,10 @@ type Achievement struct {
 
 var AchievementCatalog = make(map[int]Achievement)
 
-// achievement IDs
+// Achievement IDs
 var ROUTINE_BUSINESS = 1
 var UNITED_PINGDOM = 2
+var ARP_HOT = 3
 
 func buildAchievementCatalog() {
 	achievement := Achievement{
@@ -39,11 +40,18 @@ func buildAchievementCatalog() {
 		Description: "Successfully ping from one device to another.",
 	}
 	AchievementCatalog[UNITED_PINGDOM] = achievement
+
+	achievement = Achievement{
+		ID:          ARP_HOT,
+		Name:        "ARP It Like It's Hot",
+		Description: "Manually send an ARP request, and receive a reply.",
+	}
+	AchievementCatalog[ARP_HOT] = achievement
 }
 
 func displayAchievements() {
-	fmt.Printf("ACHIEVEMENTS:\n")
-	fmt.Printf("#\tName\t\t\t\tDescription\t\t\t\t\tUnlocked\n")
+	fmt.Printf("Achievements:\n")
+	fmt.Printf("#\tName\t\t\t\tDescription\t\t\t\t\t\tUnlocked\n")
 
 	keys := make([]int, 1, len(AchievementCatalog))
 	for k := range AchievementCatalog {
@@ -61,7 +69,7 @@ func displayAchievements() {
 			unlockedChar = "Y"
 		}
 
-		fmt.Printf("%d\t%s\t%s\t%s\n", AchievementCatalog[i].ID, PadRight(AchievementCatalog[i].Name, 25), PadRight(AchievementCatalog[i].Description, 45), unlockedChar)
+		fmt.Printf("%d\t%s\t%s\t%s\n", AchievementCatalog[i].ID, PadRight(AchievementCatalog[i].Name, 25), PadRight(AchievementCatalog[i].Description, 50), unlockedChar)
 	}
 }
 
@@ -71,16 +79,17 @@ func achievementAward(achievement Achievement) {
 	saveUserSettings()
 }
 
-// Does a check of state-based achievements
+// Does a check of state-based Achievements
 func achievementCheck() {
 	if !user_settings.AchievementsOn {
 		return
 	}
 
+	// Test state-based Achievements
 	achievementTester(ROUTINE_BUSINESS)
 }
 
-// Kicks off tests for incomplete achievements
+// Kicks off tests for incomplete Achievements
 func achievementTester(achievementID int) {
 	if !user_settings.AchievementsOn {
 		return
@@ -92,11 +101,13 @@ func achievementTester(achievementID int) {
 			achievement1Test()
 		case 2:
 			achievement2Test()
+		case 3:
+			achievement3Test()
 		}
 	}
 }
 
-// achievement 1: Create a router
+// Achievement 1: Create a router
 func achievement1Test() {
 	achievementComplete := false
 
@@ -110,9 +121,16 @@ func achievement1Test() {
 	}
 }
 
-// achievement 2: Successful ping
+// Achievement 2: Successful ping
 func achievement2Test() {
 	// If this function is called, the achievement is already complete (action-based)
 	achievement := AchievementCatalog[UNITED_PINGDOM]
+	achievementAward(achievement)
+}
+
+// Achievement 2: Successful manual ARP request
+func achievement3Test() {
+	// If this function is called, the achievement is already complete (action-based)
+	achievement := AchievementCatalog[ARP_HOT]
 	achievementAward(achievement)
 }

--- a/achievements.go
+++ b/achievements.go
@@ -1,0 +1,115 @@
+/*
+File:		achievements.go
+Author: 	https://github.com/vincebel7
+Purpose:	Achievements
+
+Note: There are two types of achievements: State-based, and action-based.
+State-based: Achievements based on network state which can be checked regularly (network has a router)
+Action-based: Achievements given when a particular action occurs (successful ping)
+*/
+
+package main
+
+import "fmt"
+
+type Achievement struct {
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	ProgramVer string `json:"program_ver"`
+}
+
+var AchievementCatalog = make(map[int]Achievement)
+
+// achievement IDs
+var ROUTINE_BUSINESS = 1
+var UNITED_PINGDOM = 2
+
+func buildAchievementCatalog() {
+	achievement := Achievement{
+		ID:   ROUTINE_BUSINESS,
+		Name: "Route-ine Business",
+	}
+	AchievementCatalog[ROUTINE_BUSINESS] = achievement
+
+	achievement = Achievement{
+		ID:   UNITED_PINGDOM,
+		Name: "United Pingdom",
+	}
+	AchievementCatalog[UNITED_PINGDOM] = achievement
+}
+
+func displayAchievements() {
+	fmt.Printf("ACHIEVEMENTS:\n")
+	fmt.Printf("#\tAchievement Name\t\tUnlocked\n")
+
+	keys := make([]int, 1, len(AchievementCatalog))
+	for k := range AchievementCatalog {
+		keys = append(keys, k)
+	}
+
+	for i := range keys {
+		if i == 0 {
+			continue
+		}
+
+		unlockedChar := "."
+
+		if _, exists := user_settings.Achievements[i]; exists {
+			unlockedChar = "Y"
+		}
+
+		fmt.Printf("%d\t%s\t%s\n", AchievementCatalog[i].ID, PadRight(AchievementCatalog[i].Name, 25), unlockedChar)
+	}
+}
+
+func achievementAward(achievement Achievement) {
+	fmt.Printf("\n[ACHIEVEMENT COMPLETE] \"%s\" (#%d)\n\n", achievement.Name, achievement.ID)
+	user_settings.Achievements[achievement.ID] = achievement
+	saveUserSettings()
+}
+
+// Does a check of state-based achievements
+func achievementCheck() {
+	if !user_settings.AchievementsOn {
+		return
+	}
+
+	achievementTester(ROUTINE_BUSINESS)
+}
+
+// Kicks off tests for incomplete achievements
+func achievementTester(achievementID int) {
+	if !user_settings.AchievementsOn {
+		return
+	}
+
+	if _, exists := user_settings.Achievements[achievementID]; !exists {
+		switch achievementID {
+		case 1:
+			achievement1Test()
+		case 2:
+			achievement2Test()
+		}
+	}
+}
+
+// achievement 1: Create a router
+func achievement1Test() {
+	achievementComplete := false
+
+	if snet.Router.ID != "" {
+		achievementComplete = true
+	}
+
+	if achievementComplete {
+		achievement := AchievementCatalog[ROUTINE_BUSINESS]
+		achievementAward(achievement)
+	}
+}
+
+// achievement 2: Successful ping
+func achievement2Test() {
+	// If this function is called, the achievement is already complete (action-based)
+	achievement := AchievementCatalog[UNITED_PINGDOM]
+	achievementAward(achievement)
+}

--- a/actions.go
+++ b/actions.go
@@ -534,7 +534,7 @@ func ipset(hostname string, ipaddr string) {
 	defaultGateway := snet.Router.Gateway.String()
 
 	fmt.Printf("\nIP Address: %s\nSubnet mask: %s\nDefault gateway: %s\n", ipaddr, subnetMask, defaultGateway)
-	fmt.Print("\nIs this correct? [Y/n/exit]")
+	fmt.Print("\nIs this correct? [Y/n]: ")
 	scanner.Scan()
 	affirmation := scanner.Text()
 
@@ -542,13 +542,11 @@ func ipset(hostname string, ipaddr string) {
 		// error checking
 		if net.ParseIP(ipaddr).To4() == nil {
 			fmt.Printf("Error: '%s' is not a valid IP address\n", ipaddr)
-
 			return
 		}
 
-	} else if strings.ToUpper(affirmation) == "EXIT" {
+	} else {
 		fmt.Println("Network changes reverted")
-
 		return
 	}
 

--- a/actions.go
+++ b/actions.go
@@ -73,7 +73,6 @@ func ping(srcID string, dstIP string, count int) {
 			continue
 		}
 
-		debug(4, "ping", srcID, "Constructing ping")
 		payload, _ := json.Marshal("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637")
 
 		icmpRequestPacket := ICMPEchoPacket{
@@ -108,6 +107,7 @@ func ping(srcID string, dstIP string, count int) {
 			if pongIcmpPacket.ControlType == 0 {
 				recvCount++
 				fmt.Printf("Reply from %s: seq=%d\n", dstIP, i)
+				achievementTester(UNITED_PINGDOM)
 			} else {
 				debug(1, "ping", srcID, "Error: Out-of-order channel")
 			}

--- a/actions.go
+++ b/actions.go
@@ -563,8 +563,12 @@ func ipset(hostname string, ipaddr string) {
 
 // Run an ARP request, but synchronize with client
 func arpSynchronized(id string, targetIP string) {
-	arp_request(id, targetIP)
-	hostDetermineDstMAC(snet.Hosts[getHostIndexFromID(id)], targetIP, false)
+	dstMAC := hostDetermineDstMAC(snet.Hosts[getHostIndexFromID(id)], targetIP, false)
+
+	if dstMAC != "" {
+		achievementTester(ARP_HOT)
+	}
+
 	actionsync[id] <- 1
 }
 

--- a/client.go
+++ b/client.go
@@ -228,7 +228,22 @@ func actionsMenu() {
 		}
 
 	case "achievements":
-		displayAchievements()
+		printAchievementsHelp := func() {
+			fmt.Println("",
+				"achievements show\tShow your achievements\n",
+				"achievements info\tShow all achievements",
+			)
+		}
+		switch action_selection {
+		case "achievements", "achievements help", "achievements ?":
+			printAchievementsHelp()
+		case "achievements show":
+			displayAchievements()
+		case "achievements info":
+			fmt.Println("Not implemented yet")
+		default:
+			fmt.Println(" Invalid command. Type 'achievements ?' for a list of commands.")
+		}
 
 	case "save":
 		save()
@@ -241,22 +256,17 @@ func actionsMenu() {
 		case "show network overview", "sh network overview":
 			overview()
 
-		case "show diagram":
+		case "show diagram", "sh diagram":
 			drawDiagram(snet.Router.ID)
-
-		case "show achievements":
-			displayAchievements()
 
 		default:
 			if len(action_selection) > 12 { // show device
 				show(action_selection[12:])
 			} else {
 				fmt.Println(
-					"COMMANDS:\n",
 					"show network overview\n",
 					"show device <hostname>\n",
-					"show diagram\n",
-					"show achievements",
+					"show diagram",
 				)
 			}
 		}
@@ -275,7 +285,7 @@ func actionsMenu() {
 				"1 - Errors\n",
 				"2 - General network traffic\n",
 				"3 - All network traffic\n",
-				"4 - All sorts of garbage (dev use)")
+				"4 - All sorts of garbage (development+learning)")
 		}
 
 	case "manual", "man":
@@ -293,7 +303,9 @@ func actionsMenu() {
 			"link <args>\t\tLinks two devices\n",
 			"unlink <args>\t\tUnlinks two devices\n",
 			"control <args>\t\tLogs in as device\n",
+
 			"\nSYSTEM COMMANDS:\n",
+			"achievements <action>\tView user achievements\n",
 			"save\t\t\tManually saves network changes\n",
 			"reload\t\t\tReloads the network file. May fix runtime bugs\n",
 			"debug <0-4>\t\tSets debug level. Default is 1\n",

--- a/client.go
+++ b/client.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 )
 
+var currentVersion = "v0.3.0"
+
 func intro() {
-	fmt.Println("ltdnet v0.3.0")
+	fmt.Println("ltdnet " + currentVersion)
 
 	if user_settings.Author == "" {
 		changeSettingsName()
@@ -152,7 +154,7 @@ func actionsMenu() {
 	case "del", "delete":
 		switch actionword2 {
 		case "router":
-			fmt.Printf("\nAre you sure you want do delete router %s? [y/n]: ", actionword3)
+			fmt.Printf("\nAre you sure you want do delete router %s? [y/N]: ", actionword3)
 			scanner.Scan()
 			confirmation := scanner.Text()
 			confirmation = strings.ToUpper(confirmation)
@@ -163,7 +165,7 @@ func actionsMenu() {
 
 		case "switch":
 			if actionword3 != "" {
-				fmt.Printf("\nAre you sure you want do delete switch %s? [y/n]: ", actionword3)
+				fmt.Printf("\nAre you sure you want do delete switch %s? [y/N]: ", actionword3)
 				scanner.Scan()
 				confirmation := scanner.Text()
 				confirmation = strings.ToUpper(confirmation)
@@ -175,7 +177,7 @@ func actionsMenu() {
 
 		case "host":
 			if actionword3 != "" {
-				fmt.Printf("\nAre you sure you want do delete host %s? [y/n]: ", actionword3)
+				fmt.Printf("\nAre you sure you want do delete host %s? [y/N]: ", actionword3)
 				scanner.Scan()
 				confirmation := scanner.Text()
 				confirmation = strings.ToUpper(confirmation)

--- a/client.go
+++ b/client.go
@@ -28,7 +28,7 @@ func startMenu() bool {
 	fmt.Println("\nPlease select an option:")
 	fmt.Println(" 1) Create new network")
 	fmt.Println(" 2) Select saved network")
-	fmt.Println(" 3) Show achievements")
+	fmt.Println(" 3) Show Achievements")
 	fmt.Println(" 4) Preferences")
 	for !selection {
 		fmt.Print("\nAction: ")
@@ -232,8 +232,9 @@ func actionsMenu() {
 	case "achievements":
 		printAchievementsHelp := func() {
 			fmt.Println("",
-				"achievements show\tShow your achievements\n",
-				"achievements info\tShow all achievements",
+				"achievements show\tShow your Achievements\n",
+				"achievements info <#>\tGet information about an Achievement\n",
+				"achievements explain\tLearn about ltdnet's Achievements system",
 			)
 		}
 		switch action_selection {

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 func intro() {
-	fmt.Println("ltdnet v0.2.11")
+	fmt.Println("ltdnet v0.3.0")
 	fmt.Println("by vincebel")
 	fmt.Println("\nPlease note that switch functionality is limited and in development")
 }
@@ -157,6 +157,10 @@ func actionsMenu() {
 			switch actionword2 {
 			case "host":
 				controlHost(actionword3)
+				save()
+
+			case "switch":
+				controlSwitch(actionword3)
 				save()
 
 			case "router":

--- a/client.go
+++ b/client.go
@@ -26,7 +26,8 @@ func startMenu() bool {
 	fmt.Println("\nPlease select an option:")
 	fmt.Println(" 1) Create new network")
 	fmt.Println(" 2) Select saved network")
-	fmt.Println(" 3) Preferences")
+	fmt.Println(" 3) Show achievements")
+	fmt.Println(" 4) Preferences")
 	for !selection {
 		fmt.Print("\nAction: ")
 
@@ -42,7 +43,10 @@ func startMenu() bool {
 			selection = true
 			advanceMenus = true
 			selectNetwork()
-		case "3", "P", "PREFERENCES", "PREF":
+		case "3", "A", "ACHIEVEMENTS":
+			selection = true
+			displayAchievements()
+		case "4", "P", "PREFERENCES", "PREF":
 			selection = true
 			preferencesMenu()
 		default:
@@ -58,8 +62,8 @@ func preferencesMenu() {
 	fmt.Println("\nUSER PREFERENCES")
 	fmt.Println("\nPlease select an option:")
 	fmt.Println(" 1) Change name")
-	fmt.Println(" 2) Disable/Enable Challenges")
-	fmt.Println(" 3) Reset Challenges")
+	fmt.Println(" 2) Disable/Enable Achievements")
+	fmt.Println(" 3) Reset Achievements")
 	fmt.Println(" 4) Reset user preferences")
 	fmt.Println(" 5) Reset all program data")
 
@@ -74,10 +78,10 @@ func preferencesMenu() {
 			selection = true
 			changeSettingsName()
 		case "2":
-			toggleChallenges()
+			toggleAchievements()
 		case "3":
 			selection = true
-			resetChallenges()
+			resetAchievements()
 		case "4":
 			selection = true
 			resetProgramSettings()
@@ -223,6 +227,9 @@ func actionsMenu() {
 			fmt.Println(" Usage: control <host|switch|router> <hostname>")
 		}
 
+	case "achievements":
+		displayAchievements()
+
 	case "save":
 		save()
 
@@ -237,11 +244,20 @@ func actionsMenu() {
 		case "show diagram":
 			drawDiagram(snet.Router.ID)
 
+		case "show achievements":
+			displayAchievements()
+
 		default:
 			if len(action_selection) > 12 { // show device
 				show(action_selection[12:])
 			} else {
-				fmt.Println(" Usage: show network overview\n\tshow device <hostname>\n\tshow diagram")
+				fmt.Println(
+					"COMMANDS:\n",
+					"show network overview\n",
+					"show device <hostname>\n",
+					"show diagram\n",
+					"show achievements",
+				)
 			}
 		}
 
@@ -269,15 +285,17 @@ func actionsMenu() {
 		os.Exit(0)
 
 	case "help", "?":
-		fmt.Println("",
+		fmt.Println(
+			"NETWORK COMMANDS:\n",
 			"show <args>\t\tDisplays information\n",
 			"add <args>\t\tAdds device to network\n",
 			"del <args>\t\tRemoves device from network\n",
 			"link <args>\t\tLinks two devices\n",
 			"unlink <args>\t\tUnlinks two devices\n",
 			"control <args>\t\tLogs in as device\n",
+			"\nSYSTEM COMMANDS:\n",
 			"save\t\t\tManually saves network changes\n",
-			"reload\t\t\tReloads the network file (May fix runtime bugs)\n",
+			"reload\t\t\tReloads the network file. May fix runtime bugs\n",
 			"debug <0-4>\t\tSets debug level. Default is 1\n",
 			"manual\t\t\tLaunches the user manual. Great for beginners!\n",
 			"exit\t\t\tExits the program",
@@ -287,6 +305,8 @@ func actionsMenu() {
 	default:
 		fmt.Println(" Invalid command. Type 'help' for a list of commands.")
 	}
+
+	achievementCheck()
 }
 
 func main() {

--- a/client.go
+++ b/client.go
@@ -14,15 +14,19 @@ import (
 
 func intro() {
 	fmt.Println("ltdnet v0.3.0")
-	fmt.Println("by vincebel")
-	fmt.Println("\nPlease note that switch functionality is limited and in development")
+
+	if user_settings.Author == "" {
+		changeSettingsName()
+	}
 }
 
-func startMenu() {
+func startMenu() bool {
+	advanceMenus := false
 	selection := false
-	fmt.Println("\nPlease create or select a network:")
+	fmt.Println("\nPlease select an option:")
 	fmt.Println(" 1) Create new network")
 	fmt.Println(" 2) Select saved network")
+	fmt.Println(" 3) Preferences")
 	for !selection {
 		fmt.Print("\nAction: ")
 
@@ -32,14 +36,59 @@ func startMenu() {
 		switch strings.ToUpper(option) {
 		case "1", "C", "NEW", "CREATE":
 			selection = true
+			advanceMenus = true
 			newNetworkPrompt()
 		case "2", "S", "SELECT":
 			selection = true
+			advanceMenus = true
 			selectNetwork()
+		case "3", "P", "PREFERENCES", "PREF":
+			selection = true
+			preferencesMenu()
 		default:
-			fmt.Println("Not a valid option. Options: 1, 2")
+			fmt.Println("Not a valid option. Options: 1, 2, 3")
 		}
 	}
+
+	return advanceMenus
+}
+
+func preferencesMenu() {
+	selection := false
+	fmt.Println("\nUSER PREFERENCES")
+	fmt.Println("\nPlease select an option:")
+	fmt.Println(" 1) Change name")
+	fmt.Println(" 2) Disable/Enable Challenges")
+	fmt.Println(" 3) Reset Challenges")
+	fmt.Println(" 4) Reset user preferences")
+	fmt.Println(" 5) Reset all program data")
+
+	for !selection {
+		fmt.Print("\nAction: ")
+
+		scanner.Scan()
+		option := scanner.Text()
+
+		switch strings.ToUpper(option) {
+		case "1":
+			selection = true
+			changeSettingsName()
+		case "2":
+			toggleChallenges()
+		case "3":
+			selection = true
+			resetChallenges()
+		case "4":
+			selection = true
+			resetProgramSettings()
+		case "5":
+			selection = true
+			resetProgramPrompt()
+		default:
+			fmt.Println("Not a valid option. Options: 1, 2, 3, 4, 5")
+		}
+	}
+
 }
 
 func actionsMenu() {
@@ -241,14 +290,23 @@ func actionsMenu() {
 }
 
 func main() {
+	loadUserSettings()
 	intro()
-	startMenu()
+
+	for {
+		if startMenu() {
+			break
+		}
+	}
+
 	go Listener()
 
 	for range snet.Hosts {
 		<-listenSync
 	}
 	fmt.Printf("\n[Notice] Debug level is set to %d\n", getDebug())
+	fmt.Printf("[Notice] Please note that switch functionality is limited and in development\n")
+
 	fmt.Println("\nltdnetOS:")
 
 	for {

--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,7 @@ func cleanTestSaves() {
 func TestNetworkSetup(t *testing.T) {
 	// Setup
 	testnetName := "testnet-" + idgen(8)
-	newNetwork(testnetName, "testUser", "24", "test")
+	newNetwork(testnetName, "24", "test")
 	go Listener()
 
 	setDebug("4")

--- a/client_test.go
+++ b/client_test.go
@@ -32,6 +32,8 @@ func TestNetworkSetup(t *testing.T) {
 	// Test 2: Add hosts
 	addHost("h1")
 	addHost("h2")
+	addHost("h3")
+	addHost("h4")
 
 	if snet.Hosts[0].Model != "ProBox 1" {
 		t.Errorf("Host not (properly) created")
@@ -40,6 +42,7 @@ func TestNetworkSetup(t *testing.T) {
 	// Test 3: Link hosts
 	linkHost("h1", "r1")
 	linkHost("h2", "r1")
+	linkHost("h3", "r1")
 
 	if (snet.Hosts[0].UplinkID == "") || (snet.Router.VSwitch.Ports[1] == "") {
 		t.Errorf("Host not (properly) linked")

--- a/connhost.go
+++ b/connhost.go
@@ -74,7 +74,7 @@ func HostConn(device string, id string) {
 						fmt.Println("Usage: ping <dest_ip> [count]")
 					}
 				}
-			case "arp":
+			case "arprequest":
 				if host.UplinkID == "" {
 					fmt.Println("Device is not connected. Please set an uplink")
 				} else if (host.IPAddr.String() == "0.0.0.0") || (host.IPAddr == nil) {
@@ -109,6 +109,8 @@ func HostConn(device string, id string) {
 			case "ipclear":
 				ipclear(host.ID)
 				save()
+			case "arp":
+				displayARPTable(host.ID)
 			case "exit", "quit", "q":
 				return
 			case "help", "?":
@@ -117,6 +119,7 @@ func HostConn(device string, id string) {
 					"dhcp\t\t\t\tGets IP configuration via DHCP\n",
 					"ipset\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
 					"ipclear\t\t\tClears an IP configuration (WARNING: This does not release any DHCP leases)\n",
+					"arp\t\t\t\tShows the host's ARP table (IP address : MAC address)\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 			default:

--- a/connhost.go
+++ b/connhost.go
@@ -109,7 +109,7 @@ func HostConn(device string, id string) {
 			case "ipclear":
 				ipclear(host.ID)
 				save()
-			case "arp":
+			case "arptable":
 				displayARPTable(host.ID)
 			case "exit", "quit", "q":
 				return
@@ -119,7 +119,7 @@ func HostConn(device string, id string) {
 					"dhcp\t\t\t\tGets IP configuration via DHCP\n",
 					"ipset\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
 					"ipclear\t\t\tClears an IP configuration (WARNING: This does not release any DHCP leases)\n",
-					"arp\t\t\t\tShows the host's ARP table (IP address : MAC address)\n",
+					"arptable\t\t\tShows the host's ARP table (IP address : MAC address)\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 			default:

--- a/connrouter.go
+++ b/connrouter.go
@@ -74,7 +74,7 @@ func RouterConn(device string, id string) {
 			case "ipclear":
 				ipclear(snet.Router.Gateway.String())
 				save()
-			case "arp":
+			case "arptable":
 				displayARPTable(snet.Router.ID)
 			case "exit", "quit", "q":
 				return
@@ -84,7 +84,7 @@ func RouterConn(device string, id string) {
 					"dhcpserver\t\t\tDisplays DHCP server and DHCP pool settings\n",
 					"ipset\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
 					"ipclear\t\t\tClears an IP configuration\n",
-					"arp\t\t\t\tShows the router's ARP table (IP address : MAC address)\n",
+					"arptable\t\t\tShows the router's ARP table (IP address : MAC address)\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 			default:

--- a/connrouter.go
+++ b/connrouter.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"fmt"
-	//"time"
 	"strconv"
 	"strings"
 )
@@ -35,6 +34,7 @@ func RouterConn(device string, id string) {
 
 			switch actionword1 {
 			case "":
+
 			case "ping":
 				if (snet.Router.Gateway.String() == "0.0.0.0") || (snet.Router.Gateway == nil) {
 					fmt.Println("Device does not have IP configuration. Please statically assign an IP configuration")
@@ -48,7 +48,7 @@ func RouterConn(device string, id string) {
 						}
 						<-actionsync[id]
 					} else {
-						fmt.Println("Usage: ping <dest_ip> [seconds]")
+						fmt.Println("Usage: ping <dst_ip> [seconds]")
 					}
 				}
 			case "arprequest":
@@ -64,27 +64,88 @@ func RouterConn(device string, id string) {
 				}
 			case "dhcpserver":
 				displayDHCPServer()
-			case "ipset":
-				if len(action) > 1 {
-					ipset(snet.Router.Hostname, action[1])
-					save()
-				} else {
-					fmt.Println("Usage: ipset <ip_address>")
+
+			case "ip":
+				printIPHelp := func() {
+					fmt.Println("",
+						"ip address\t\t\tShow IP configuration\n",
+						"ip route\t\t\tShow known routes\n",
+						"ip set\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
+						"ip clear\t\t\tClears an IP configuration (WARNING: This does not release DHCP leases)",
+					)
 				}
-			case "ipclear":
-				ipclear(snet.Router.Gateway.String())
-				save()
-			case "arptable":
-				displayARPTable(snet.Router.ID)
+
+				if len(action) > 1 {
+					switch action[1] {
+					case "a", "addr", "address":
+						netsizeInt, _ := strconv.Atoi(snet.Netsize)
+						subnetMask := prefixLengthToSubnetMask(netsizeInt)
+						fmt.Println("IPv4 address: " + snet.Router.Gateway.String())
+						fmt.Println("Subnet mask: " + subnetMask)
+
+					case "route":
+						fmt.Println("Routing not implemented yet.")
+
+					case "set":
+						if len(action) > 2 {
+							ipset(snet.Router.Hostname, action[2])
+							save()
+						} else {
+							fmt.Println("Usage: ipset <ip_address>")
+						}
+
+					case "clear":
+						ipclear(snet.Router.Gateway.String())
+						save()
+
+					case "help", "?":
+						printIPHelp()
+
+					default:
+						fmt.Println(" Invalid command. Type 'ip ?' for a list of commands.")
+					}
+				} else {
+					printIPHelp()
+				}
+
+			case "arp":
+				if len(action) > 1 {
+					switch action[1] {
+					case "request":
+						if len(action) > 2 {
+							go arpSynchronized(id, action[2])
+							<-actionsync[id]
+						} else {
+							fmt.Println("Usage: arp request <target_ip>")
+						}
+
+					case "clear":
+						snet.Router.ARPTable = make(map[string]string)
+						fmt.Println("ARP table cleared")
+
+					case "help", "?":
+						fmt.Println("",
+							"arp\t\t\tShows the device's ARP table (IP address : MAC address)\n",
+							"arp request <dst_ip>\tManually ARP request an address",
+							"arp clear\t\tClears the device's ARP table",
+						)
+
+					default:
+						fmt.Println(" Invalid command. Type '?' for a list of commands.")
+					}
+				} else {
+					displayARPTable(snet.Router.ID)
+				}
+
 			case "exit", "quit", "q":
 				return
+
 			case "help", "?":
 				fmt.Println("",
-					"ping <dest_ip> [seconds]\tPings an IP address\n",
+					"ping <dst_ip> [seconds]\tPings an IP address\n",
 					"dhcpserver\t\t\tDisplays DHCP server and DHCP pool settings\n",
-					"ipset\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
-					"ipclear\t\t\tClears an IP configuration\n",
-					"arptable\t\t\tShows the router's ARP table (IP address : MAC address)\n",
+					"ip\t\t\t\tManage IP addressing\n",
+					"arp\t\t\t\tShow and manage the ARP table\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 			default:

--- a/connrouter.go
+++ b/connrouter.go
@@ -51,7 +51,7 @@ func RouterConn(device string, id string) {
 						fmt.Println("Usage: ping <dest_ip> [seconds]")
 					}
 				}
-			case "arp":
+			case "arprequest":
 				if (snet.Router.Gateway.String() == "0.0.0.0") || (snet.Router.Gateway == nil) {
 					fmt.Println("Device does not have IP configuration. Please statically assign an IP configuration")
 				} else {
@@ -64,7 +64,6 @@ func RouterConn(device string, id string) {
 				}
 			case "dhcpserver":
 				displayDHCPServer()
-				save()
 			case "ipset":
 				if len(action) > 1 {
 					ipset(snet.Router.Hostname, action[1])
@@ -75,6 +74,8 @@ func RouterConn(device string, id string) {
 			case "ipclear":
 				ipclear(snet.Router.Gateway.String())
 				save()
+			case "arp":
+				displayARPTable(snet.Router.ID)
 			case "exit", "quit", "q":
 				return
 			case "help", "?":
@@ -83,6 +84,7 @@ func RouterConn(device string, id string) {
 					"dhcpserver\t\t\tDisplays DHCP server and DHCP pool settings\n",
 					"ipset\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
 					"ipclear\t\t\tClears an IP configuration\n",
+					"arp\t\t\t\tShows the router's ARP table (IP address : MAC address)\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 			default:

--- a/connswitch.go
+++ b/connswitch.go
@@ -8,8 +8,6 @@ package main
 
 import (
 	"fmt"
-	//"time"
-
 	"strings"
 )
 
@@ -62,30 +60,50 @@ func SwitchConn(id string) {
 
 			switch actionword1 {
 			case "":
+
 			case "ping":
 				fmt.Println("Not yet implemented on switches")
-			case "arprequest":
+
+			case "ip":
 				fmt.Println("Not yet implemented on switches")
-			case "ipset":
-				fmt.Println("Not yet implemented on switches")
-			case "ipclear":
-				fmt.Println("Not yet implemented on switches")
-				//ipclear(sw.ID)
-				//save()
-			case "arptable":
+
+			case "arp":
 				fmt.Println("Not yet implemented on switches")
 				//displayARPTable(sw.ID)
-			case "mactable":
-				displayMACTable(sw.ID)
+
+			case "mac":
+				if len(action) > 1 {
+					switch action[1] {
+					case "clear":
+						if snet.Router.VSwitch.ID == id {
+							snet.Router.VSwitch.MACTable = make(map[string]int)
+						} else {
+							snet.Switches[getSwitchIndexFromID(id)].MACTable = make(map[string]int)
+						}
+						fmt.Println("MAC table cleared")
+
+					case "help", "?":
+						fmt.Println("",
+							"mac\t\t\tShows the device's MAC table (MAC address : Interface)\n",
+							"mac clear\t\tClears the device's MAC table",
+						)
+
+					default:
+						fmt.Println(" Invalid command. Type '?' for a list of commands.")
+					}
+				} else {
+					displayMACTable(sw.ID)
+				}
+
 			case "exit", "quit", "q":
 				return
+
 			case "help", "?":
 				fmt.Println("",
-					//"ping <dest_ip> [seconds]\tPings an IP address\n",
-					//"ipset\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
-					//"ipclear\t\t\tClears an IP configuration\n",
-					//"arptable\t\t\tShows the switch's ARP table (IP address : MAC address)\n",
-					"mactable\t\t\tShows the switch's MAC address table (MAC address : Switchport #)\n",
+					//"ping <dst_ip> [seconds]\tPings an IP address\n",
+					//"ip\t\t\t\tManage IP addressing\n",
+					//"arp\t\t\t\tShow and manage the ARP table\n",
+					"mac\t\t\t\tShow and manage the MAC address table\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 			default:

--- a/connswitch.go
+++ b/connswitch.go
@@ -1,0 +1,96 @@
+/*
+File:		connswitch.go
+Author: 	https://github.com/vincebel7
+Purpose:	Handles connection and interface for switches
+*/
+
+package main
+
+import (
+	"fmt"
+	//"time"
+
+	"strings"
+)
+
+func controlSwitch(hostname string) {
+	fmt.Printf("Attempting to control switch %s...\n", hostname)
+	for i := range snet.Switches {
+		if snet.Switches[i].Hostname == hostname {
+			SwitchConn(snet.Switches[i].ID)
+			return
+		}
+	}
+
+	if snet.Router.VSwitch.Hostname == hostname {
+		SwitchConn(snet.Router.VSwitch.ID)
+		return
+	}
+
+	fmt.Println("Switch not found")
+}
+
+func SwitchConn(id string) {
+	sw := Switch{}
+
+	//interface
+	fmt.Printf("\n")
+	action_selection := ""
+	for strings.ToUpper(action_selection) != "EXIT" {
+		for i := range snet.Switches {
+			if snet.Switches[i].ID == id {
+				sw = snet.Switches[i]
+			}
+		}
+		if snet.Router.VSwitch.ID == id {
+			sw = snet.Router.VSwitch
+		}
+		if sw.ID == "" {
+			fmt.Println("Error: ID cannot be located. Please try again")
+			return
+		}
+
+		fmt.Printf("%s> ", sw.Hostname)
+		scanner.Scan()
+		action_selection := scanner.Text()
+		actionword1 := ""
+		if action_selection != "" {
+			action := strings.Fields(action_selection)
+			if len(action) > 0 {
+				actionword1 = action[0]
+			}
+
+			switch actionword1 {
+			case "":
+			case "ping":
+				fmt.Println("Not yet implemented on switches")
+			case "arprequest":
+				fmt.Println("Not yet implemented on switches")
+			case "ipset":
+				fmt.Println("Not yet implemented on switches")
+			case "ipclear":
+				fmt.Println("Not yet implemented on switches")
+				//ipclear(sw.ID)
+				//save()
+			case "arptable":
+				fmt.Println("Not yet implemented on switches")
+				//displayARPTable(sw.ID)
+			case "mactable":
+				displayMACTable(sw.ID)
+			case "exit", "quit", "q":
+				return
+			case "help", "?":
+				fmt.Println("",
+					//"ping <dest_ip> [seconds]\tPings an IP address\n",
+					//"ipset\t\t\t\tStarts dialogue for statically assigning an IP configuration\n",
+					//"ipclear\t\t\tClears an IP configuration\n",
+					//"arptable\t\t\tShows the switch's ARP table (IP address : MAC address)\n",
+					"mactable\t\t\tShows the switch's MAC address table (MAC address : Switchport #)\n",
+					"exit\t\t\t\tReturns to main menu",
+				)
+			default:
+				fmt.Println(" Invalid command. Type 'help' for a list of commands.")
+			}
+		}
+	}
+}

--- a/display.go
+++ b/display.go
@@ -279,7 +279,7 @@ func show(hostname string) {
 }
 
 func displayARPTable(deviceID string) {
-	ARPTable := make(map[string]string)
+	var ARPTable map[string]string
 
 	if snet.Router.ID == deviceID {
 		ARPTable = snet.Router.ARPTable
@@ -292,6 +292,24 @@ func displayARPTable(deviceID string) {
 
 	for i := range ARPTable {
 		fmt.Printf("%s\t\t%s\n", i, ARPTable[i])
+	}
+	fmt.Printf("\n")
+}
+
+func displayMACTable(deviceID string) {
+	var MACTable map[string]int
+
+	if snet.Router.VSwitch.ID == deviceID {
+		MACTable = snet.Router.VSwitch.MACTable
+	} else {
+		MACTable = snet.Switches[getSwitchIndexFromID(deviceID)].MACTable
+	}
+
+	fmt.Printf("MAC Table:\n")
+	fmt.Printf("MAC Address\t\tInterface #\n")
+
+	for i := range MACTable {
+		fmt.Printf("%s\t%d\n", i, MACTable[i])
 	}
 	fmt.Printf("\n")
 }

--- a/display.go
+++ b/display.go
@@ -277,3 +277,21 @@ func show(hostname string) {
 		fmt.Printf("\tVSwitch ID: \t%s\n", snet.Router.VSwitch.ID)
 	}
 }
+
+func displayARPTable(deviceID string) {
+	ARPTable := make(map[string]string)
+
+	if snet.Router.ID == deviceID {
+		ARPTable = snet.Router.ARPTable
+	} else {
+		ARPTable = snet.Hosts[getHostIndexFromID(deviceID)].ARPTable
+	}
+
+	fmt.Printf("ARP Table:\n")
+	fmt.Printf("IP Address\t\tMAC Address\n")
+
+	for i := range ARPTable {
+		fmt.Printf("%s\t\t%s\n", i, ARPTable[i])
+	}
+	fmt.Printf("\n")
+}

--- a/display.go
+++ b/display.go
@@ -221,6 +221,11 @@ func show(hostname string) {
 		id = 0
 	}
 
+	if snet.Router.VSwitch.Hostname == hostname {
+		device_type = "vswitch"
+		id = 0
+	}
+
 	for i := range snet.Hosts {
 		if snet.Hosts[i].Hostname == hostname {
 			device_type = "host"
@@ -267,6 +272,11 @@ func show(hostname string) {
 		fmt.Printf("\tID:\t\t%s\n", snet.Switches[id].ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Switches[id].Model)
 		fmt.Printf("\tMgmt IP:\t%s\n\n", snet.Switches[id].MgmtIP)
+	} else if device_type == "vswitch" {
+		fmt.Printf("\nSwitch %s\n", snet.Router.VSwitch.Hostname)
+		fmt.Printf("\tID:\t\t%s\n", snet.Router.VSwitch.ID)
+		fmt.Printf("\tModel:\t\t%s\n", snet.Router.VSwitch.Model)
+		fmt.Printf("\tMgmt IP:\t%s\n\n", snet.Router.VSwitch.MgmtIP)
 	} else if device_type == "router" {
 		fmt.Printf("\nRouter %s\n", snet.Router.Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Router.ID)

--- a/helpers.go
+++ b/helpers.go
@@ -201,3 +201,10 @@ func removeStringFromSlice(s []string, i int) []string {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]
 }
+
+func PadRight(str string, length int) string {
+	if len(str) >= length {
+		return str // Return the original string if it's already the desired length or longer
+	}
+	return str + fmt.Sprintf("%*s", length-len(str), "")
+}

--- a/host.go
+++ b/host.go
@@ -13,14 +13,15 @@ import (
 )
 
 type Host struct {
-	ID             string `json:"id"`
-	Model          string `json:"model"`
-	MACAddr        string `json:"macaddr"`
-	Hostname       string `json:"hostname"`
-	IPAddr         net.IP `json:"ipaddr"`
-	SubnetMask     string `json:"mask"`
-	DefaultGateway net.IP `json:"gateway"`
-	UplinkID       string `json:"uplinkid"`
+	ID             string            `json:"id"`
+	Model          string            `json:"model"`
+	MACAddr        string            `json:"macaddr"`
+	Hostname       string            `json:"hostname"`
+	IPAddr         net.IP            `json:"ipaddr"`
+	SubnetMask     string            `json:"mask"`
+	DefaultGateway net.IP            `json:"gateway"`
+	UplinkID       string            `json:"uplinkid"`
+	ARPTable       map[string]string `json:"arptable"`
 }
 
 func NewProbox(hostname string) Host {
@@ -29,6 +30,7 @@ func NewProbox(hostname string) Host {
 	p.Model = "ProBox 1"
 	p.MACAddr = macgen()
 	p.Hostname = hostname
+	p.ARPTable = make(map[string]string)
 
 	return p
 }

--- a/listener.go
+++ b/listener.go
@@ -240,25 +240,25 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 	}
 }
 
-func listenSwitchportChannel(id string) {
+func listenSwitchportChannel(switchportID string) {
 	for {
-		rawFrame := <-channels[id]
-		debug(4, "listenSwitchportChannel", id, "(Switch) Received unicast frame")
+		rawFrame := <-channels[switchportID]
+		debug(4, "listenSwitchportChannel", switchportID, "(Switch) Received unicast frame")
 
-		port := getSwitchportIDFromLink(id)
-		checkMACTable(readFrame(rawFrame).SrcMAC, id, port)
+		port := getSwitchportIDFromLink(switchportID)
+		checkMACTable(readFrame(rawFrame).SrcMAC, switchportID, port)
 
-		go switchportActionHandler(rawFrame, id)
+		go switchportActionHandler(rawFrame, switchportID)
 	}
 }
 
-func switchportActionHandler(rawFrame json.RawMessage, id string) {
-	debug(4, "switchportActionHandler", id, "My packet")
-	if readFrame(rawFrame).DstMAC == "FF:FF:FF:FF:FF:FF" {
+func switchportActionHandler(rawFrame json.RawMessage, switchportID string) {
+	debug(4, "switchportActionHandler", switchportID, "My packet")
+	if readFrame(rawFrame).DstMAC == "FF:FF:FF:FF:FF:FF" { // Broadcast
 		channels["FFFFFFFF"] <- rawFrame
-	} else if false { //TODO how to receive mgmt frames
+	} else if false { // Traffic for switch. TODO how to receive mgmt frames
 		//data := frame.Data.Data.Data
-	} else {
-		switchforward(readFrame(rawFrame), id)
+	} else { // Normal frame forward
+		switchforward(readFrame(rawFrame), switchportID)
 	}
 }

--- a/listener.go
+++ b/listener.go
@@ -89,11 +89,12 @@ func generateRouterChannels() {
 func listenBroadcastChannel() { //Listens for broadcast frames on FF.. and broadcasts
 	for {
 		rawFrame := <-channels["FFFFFFFF"]
-		debug(4, "listenBroadcastChannel", "Listener", "detected broadcast")
 
+		debug(4, "listenBroadcastChannel", snet.Router.ID, "Received broadcast frame")
 		go actionHandler(rawFrame, snet.Router.ID)
 
 		for i := range snet.Hosts {
+			debug(4, "listenHlistenBroadcastChannelostChannel", snet.Hosts[i].ID, "Received broadcast frame")
 			go actionHandler(rawFrame, snet.Hosts[i].ID)
 		}
 	}
@@ -119,8 +120,6 @@ func listenRouterChannel() {
 
 // Should actions be broken into functions?
 func actionHandler(rawFrame json.RawMessage, id string) {
-	debug(4, "actionHandler", id, "About to handle a frame")
-
 	frame := readFrame(rawFrame)
 
 	switch frame.EtherType {
@@ -160,21 +159,44 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 
 	case "0x0800": // IPv4
 		packet := readIPv4Packet(frame.Data)
+		packetHeader := readIPv4PacketHeader(packet.Header)
 
-		switch readIPv4PacketHeader(packet.Header).Protocol {
+		switch packetHeader.Protocol {
 		case 1: // ICMP
 			icmpPacket := readICMPEchoPacket(packet.Data)
 
 			switch icmpPacket.ControlType {
 			case 8:
 				debug(3, "actionHandler", id, "Ping request received")
-				pong(id, frame)
+
+				// Check if target device at network-level
+				amTarget := false
+				if (snet.Router.ID == id) && (packetHeader.DstIP == snet.Router.Gateway.String()) {
+					amTarget = true
+				} else if (snet.Router.ID != id) && (packetHeader.DstIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
+					amTarget = true
+				}
+
+				if amTarget {
+					pong(id, frame)
+				}
 
 			case 0:
 				debug(3, "actionHandler", id, "Ping reply received")
-				sockets := socketMaps[id]
-				socketID := "icmp_" + strconv.Itoa(icmpPacket.Identifier)
-				sockets[socketID] <- frame
+
+				// Check if target device at network-level
+				amTarget := false
+				if (snet.Router.ID == id) && (packetHeader.DstIP == snet.Router.Gateway.String()) {
+					amTarget = true
+				} else if (snet.Router.ID != id) && (packetHeader.DstIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
+					amTarget = true
+				}
+
+				if amTarget {
+					sockets := socketMaps[id]
+					socketID := "icmp_" + strconv.Itoa(icmpPacket.Identifier)
+					sockets[socketID] <- frame
+				}
 			}
 
 		case 17: // UDP
@@ -243,7 +265,7 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 func listenSwitchportChannel(switchportID string) {
 	for {
 		rawFrame := <-channels[switchportID]
-		debug(4, "listenSwitchportChannel", switchportID, "(Switch) Received unicast frame")
+		debug(4, "listenSwitchportChannel", switchportID, "(Switch) Received unicast frame from port "+switchportID)
 
 		port := getSwitchportIDFromLink(switchportID)
 		checkMACTable(readFrame(rawFrame).SrcMAC, switchportID, port)
@@ -253,7 +275,6 @@ func listenSwitchportChannel(switchportID string) {
 }
 
 func switchportActionHandler(rawFrame json.RawMessage, switchportID string) {
-	debug(4, "switchportActionHandler", switchportID, "My packet")
 	if readFrame(rawFrame).DstMAC == "FF:FF:FF:FF:FF:FF" { // Broadcast
 		channels["FFFFFFFF"] <- rawFrame
 	} else if false { // Traffic for switch. TODO how to receive mgmt frames

--- a/network.go
+++ b/network.go
@@ -65,6 +65,7 @@ func newNetwork(netname string, networkPrefix string, saveType string) {
 		ID:         netid,
 		Name:       netname,
 		Netsize:    networkPrefix,
+		ProgramVer: currentVersion,
 		DebugLevel: 1,
 	}
 
@@ -172,12 +173,37 @@ func loadNetwork(netname string, saveType string) {
 		fmt.Printf("err: %v", err)
 	}
 
+	// Version check
+	migrate := false
+	if net.ProgramVer != currentVersion {
+		fmt.Print("The selected save file was created in an older version. Attempt migrating? [y/N]: ")
+
+		scanner.Scan()
+		migrateSelection := strings.ToUpper(scanner.Text())
+
+		switch migrateSelection {
+		case "Y", "YES":
+			// "Migrate". Will make this more intelligent eventually
+			net.ProgramVer = currentVersion
+			migrate = true
+		default:
+			startMenu()
+			return
+		}
+	}
+
 	// Clear MAC tables (ARP, MAC address table) on new launch
 	net.ClearMACTables()
 
 	//save global
 	snet = net
-	fmt.Printf("Loaded %s\n", snet.Name)
+
+	// Save successful version migration
+	if migrate {
+		save()
+	}
+
+	fmt.Printf("Loaded \"%s\"\n", snet.Name)
 }
 
 func save() {

--- a/network.go
+++ b/network.go
@@ -35,9 +35,28 @@ var scanner = bufio.NewScanner(os.Stdin)
 
 func newNetworkPrompt() {
 	fmt.Println("Creating a new network")
-	fmt.Print("Your new network's name: ")
-	scanner.Scan()
-	netname := scanner.Text()
+
+	var netname = ""
+	for {
+		fmt.Print("Your new network's name: ")
+		scanner.Scan()
+		netname = scanner.Text()
+
+		// Check if file already exists
+		filename := "saves/user_saves/" + netname + ".json"
+		if _, err := os.Stat(filename); err == nil {
+			// File exists
+			fmt.Println("\nError: A network with this name already exists!")
+
+		} else if !os.IsNotExist(err) {
+			// Some other error occurred
+			log.Fatal(err)
+		} else if netname == "" {
+			fmt.Println("\nError: Network name cannot be blank.")
+		} else {
+			break
+		}
+	}
 
 	class_valid := false
 	networkPrefix := "24"
@@ -74,7 +93,7 @@ func newNetwork(netname string, networkPrefix string, saveType string) {
 		log.Println(err)
 	}
 
-	// Write to file
+	// Determine the file path
 	filename := ""
 	if saveType == "user" {
 		filename = "saves/user_saves/" + netname + ".json"

--- a/network.go
+++ b/network.go
@@ -178,6 +178,9 @@ func loadNetwork(netname string, saveType string) {
 		fmt.Printf("err: %v", err)
 	}
 
+	// Clear MAC tables (ARP, MAC address table) on new launch
+	net.ClearMACTables()
+
 	//save global
 	snet = net
 	fmt.Printf("Loaded %s\n", snet.Name)
@@ -197,4 +200,22 @@ func save() {
 	f.Write(marshString)
 	os.Truncate(filename, int64(len(marshString)))
 	fmt.Println("Network saved")
+}
+
+func (n *Network) ClearMACTables() {
+	// Host ARP tables
+	for _, host := range n.Hosts {
+		host.ARPTable = make(map[string]string)
+	}
+
+	// Router ARP table
+	n.Router.ARPTable = make(map[string]string)
+
+	// Switch MAC address tables
+	for _, sw := range n.Switches {
+		sw.MACTable = make(map[string]int)
+	}
+
+	// VSwitch MAC address table
+	n.Router.VSwitch.MACTable = make(map[string]int)
 }

--- a/network.go
+++ b/network.go
@@ -21,7 +21,6 @@ import (
 type Network struct {
 	ID         string   `json:"id"`
 	Name       string   `json:"name"`
-	Author     string   `json:"author"`
 	Netsize    string   `json:"netsize"`
 	Router     Router   `json:"router"`
 	Switches   []Switch `json:"switches"`
@@ -40,10 +39,6 @@ func newNetworkPrompt() {
 	scanner.Scan()
 	netname := scanner.Text()
 
-	fmt.Print("\nYour name: ")
-	scanner.Scan()
-	username := scanner.Text()
-
 	class_valid := false
 	networkPrefix := "24"
 	for !class_valid {
@@ -61,15 +56,14 @@ func newNetworkPrompt() {
 		}
 	}
 
-	newNetwork(netname, username, networkPrefix, "user")
+	newNetwork(netname, networkPrefix, "user")
 }
 
-func newNetwork(netname string, username string, networkPrefix string, saveType string) {
+func newNetwork(netname string, networkPrefix string, saveType string) {
 	netid := idgen(8)
 	net := Network{
 		ID:         netid,
 		Name:       netname,
-		Author:     username,
 		Netsize:    networkPrefix,
 		DebugLevel: 1,
 	}

--- a/router.go
+++ b/router.go
@@ -16,13 +16,14 @@ import (
 )
 
 type Router struct {
-	ID       string   `json:"id"`
-	Model    string   `json:"model"`
-	MACAddr  string   `json:"macaddr"` // LAN-facing interface
-	Hostname string   `json:"hostname"`
-	Gateway  net.IP   `json:"gateway"`
-	VSwitch  Switch   `json:"vswitchid"` // Virtual built-in switch to router
-	DHCPPool DHCPPool `json:"dhcp_pool"` // Instance of DHCPPool
+	ID       string            `json:"id"`
+	Model    string            `json:"model"`
+	MACAddr  string            `json:"macaddr"` // LAN-facing interface
+	Hostname string            `json:"hostname"`
+	Gateway  net.IP            `json:"gateway"`
+	VSwitch  Switch            `json:"vswitchid"` // Virtual built-in switch to router
+	DHCPPool DHCPPool          `json:"dhcp_pool"` // Instance of DHCPPool
+	ARPTable map[string]string `json:"arptable"`
 }
 
 type DHCPPool struct {
@@ -49,6 +50,7 @@ func NewBobcat(hostname string) Router {
 	bobcat.Model = "Bobcat 100"
 	bobcat.MACAddr = macgen()
 	bobcat.Hostname = hostname
+	bobcat.ARPTable = make(map[string]string)
 
 	vSwitch := addVirtualSwitch(BOBCAT_PORTS)
 	bobcat.VSwitch = vSwitch
@@ -62,6 +64,7 @@ func NewOsiris(hostname string) Router {
 	osiris.Model = "Osiris 2-I"
 	osiris.MACAddr = macgen()
 	osiris.Hostname = hostname
+	osiris.ARPTable = make(map[string]string)
 
 	vSwitch := addVirtualSwitch(OSIRIS_PORTS)
 	osiris.VSwitch = vSwitch

--- a/router.go
+++ b/router.go
@@ -121,6 +121,7 @@ func addRouter(routerHostname string, routerModel string) {
 	for i := 0; i < getActivePorts(snet.Router.VSwitch); i++ {
 		go listenSwitchportChannel(snet.Router.VSwitch.PortIDs[i])
 	}
+	achievementTester(ROUTINE_BUSINESS)
 }
 
 func delRouter() {

--- a/switch.go
+++ b/switch.go
@@ -23,6 +23,7 @@ type Switch struct {
 	Ports    []string       `json:"ports"`   // maps port # to downlink ID
 	PortIDs  []string       `json:"portids"` // maps port # to Port ID
 	//PortMACs []string       `json:"portmacs"` // maps port # to interface MAC address
+	ARPTable map[string]string `json:"arptable"`
 }
 
 func NewSumerian2100(hostname string) Switch {
@@ -31,6 +32,7 @@ func NewSumerian2100(hostname string) Switch {
 	s.Model = "Sumerian 2100"
 	s.Hostname = hostname
 	s.Maxports = 4
+	s.ARPTable = make(map[string]string)
 
 	return s
 }
@@ -101,30 +103,30 @@ func delSwitch() {
 	//TODO For all linked devices, unlink. then delete
 }
 
-func lookupMACTable(macaddr string, id string) int { // For looking up addresses
-	resultPort := -1 // made this recent change that might have fixed? idk
-	table := make(map[string]int)
-	if isSwitchportID(snet.Router.VSwitch, id) {
-		table = snet.Router.VSwitch.MACTable
+func lookupMACTable(dstMAC string, switchportID string) int { // For looking up addresses
+	resultPort := -1
+	var MACTable map[string]int
+
+	if isSwitchportID(snet.Router.VSwitch, switchportID) {
+		MACTable = snet.Router.VSwitch.MACTable
 	} else {
 		for i := range snet.Switches {
-			if isSwitchportID(snet.Switches[i], id) {
-				table = snet.Switches[i].MACTable
+			if isSwitchportID(snet.Switches[i], switchportID) {
+				MACTable = snet.Switches[i].MACTable
 			}
 		}
 	}
 
-	//if switch
-	for k, v := range table {
-		if k == macaddr {
-			resultPort = v
+	for k := range MACTable {
+		if k == dstMAC {
+			resultPort = MACTable[k]
 		}
 	}
 
 	return resultPort
 }
 
-func checkMACTable(macaddr string, id string, port int) { // For checking table on incoming frames
+func checkMACTable(macaddr string, id string, port int) { // For updating MAC table on incoming frames
 	result := 0
 	table := make(map[string]int)
 	if isSwitchportID(snet.Router.VSwitch, id) {
@@ -148,7 +150,7 @@ func checkMACTable(macaddr string, id string, port int) { // For checking table 
 		}
 	}
 
-	if result == -1 {
+	if result == 0 {
 		msg := "Address " + macaddr + " not found in MAC table. Adding"
 		debug(3, "learnMACTable", id, msg)
 		addMACEntry(macaddr, id, port)
@@ -210,23 +212,25 @@ func assignSwitchport(sw Switch, id string) Switch {
 	return sw
 }
 
-func switchforward(frame Frame, id string) {
+func switchforward(frame Frame, switchportID string) {
 	srcMAC := frame.SrcMAC
 	dstMAC := frame.DstMAC
 	linkID := ""
+	floodFrame := false
 
-	outboundPort := lookupMACTable(dstMAC, id)
+	outboundPort := lookupMACTable(dstMAC, switchportID)
 
 	if outboundPort == -1 { // No matching port for this MAC address was found in the MAC address table.
-		debug(4, "switchforward", id, "Warning: Not found in MAC table, using bypass") //TODO implement flooding
-		linkID = getIDfromMAC(dstMAC)
+		debug(4, "switchforward", switchportID, "Warning: Not found in MAC table, using bypass") //TODO implement flooding
+		//linkID = getIDfromMAC(dstMAC)
+		floodFrame = true
 	} else {
-		if isSwitchportID(snet.Router.VSwitch, id) {
+		if isSwitchportID(snet.Router.VSwitch, switchportID) {
 			linkID = snet.Router.VSwitch.Ports[outboundPort]
 		} else {
 			for i := range snet.Switches {
-				debug(3, "switchforward", id, "Should never print this yet")
-				if isSwitchportID(snet.Switches[i], id) {
+				debug(3, "switchforward", switchportID, "Should never print this yet")
+				if isSwitchportID(snet.Switches[i], switchportID) {
 					linkID = snet.Switches[i].Ports[outboundPort]
 				}
 			}
@@ -241,7 +245,18 @@ func switchforward(frame Frame, id string) {
 		Data:      p,
 	}
 	outFrame, _ := json.Marshal(f)
-	channels[linkID] <- outFrame
+
+	if floodFrame {
+		debug(4, "switchforward", snet.Router.VSwitch.ID, "Flooding frame on all ports")
+		for port := range snet.Router.VSwitch.Ports {
+			linkID = snet.Router.VSwitch.Ports[port]
+			if snet.Router.VSwitch.PortIDs[port] != switchportID { // Don't send out source interface
+				channels[linkID] <- outFrame
+			}
+		}
+	} else {
+		channels[linkID] <- outFrame
+	}
 }
 
 func freeSwitchport(link string) {

--- a/switch.go
+++ b/switch.go
@@ -142,7 +142,7 @@ func checkMACTable(macaddr string, id string, port int) { // For updating MAC ta
 	for k, v := range table {
 		if k == macaddr {
 			if v == port {
-				debug(4, "checkMACTable", id, "Address found in MAC table")
+				debug(4, "checkMACTable", id, "Source address found in MAC table")
 				result = v
 			} else {
 				delMACEntry(macaddr, id, port)
@@ -151,7 +151,7 @@ func checkMACTable(macaddr string, id string, port int) { // For updating MAC ta
 	}
 
 	if result == 0 {
-		msg := "Address " + macaddr + " not found in MAC table. Adding"
+		msg := "Source address " + macaddr + " not found in MAC table. Adding"
 		debug(3, "learnMACTable", id, msg)
 		addMACEntry(macaddr, id, port)
 	}
@@ -221,15 +221,15 @@ func switchforward(frame Frame, switchportID string) {
 	outboundPort := lookupMACTable(dstMAC, switchportID)
 
 	if outboundPort == -1 { // No matching port for this MAC address was found in the MAC address table.
-		debug(4, "switchforward", switchportID, "Warning: Not found in MAC table, using bypass") //TODO implement flooding
-		//linkID = getIDfromMAC(dstMAC)
 		floodFrame = true
 	} else {
 		if isSwitchportID(snet.Router.VSwitch, switchportID) {
+			debug(4, "switchforward", snet.Router.VSwitch.ID, "Destination address found in MAC table.")
 			linkID = snet.Router.VSwitch.Ports[outboundPort]
 		} else {
+			debug(3, "switchforward", switchportID, "Should never print this yet - outer")
 			for i := range snet.Switches {
-				debug(3, "switchforward", switchportID, "Should never print this yet")
+				debug(3, "switchforward", switchportID, "Should never print this yet - inner")
 				if isSwitchportID(snet.Switches[i], switchportID) {
 					linkID = snet.Switches[i].Ports[outboundPort]
 				}
@@ -247,7 +247,7 @@ func switchforward(frame Frame, switchportID string) {
 	outFrame, _ := json.Marshal(f)
 
 	if floodFrame {
-		debug(4, "switchforward", snet.Router.VSwitch.ID, "Flooding frame on all ports")
+		debug(4, "switchforward", snet.Router.VSwitch.ID, "Destination address not found in MAC table. Flooding frame on all ports")
 		for port := range snet.Router.VSwitch.Ports {
 			linkID = snet.Router.VSwitch.Ports[port]
 			if snet.Router.VSwitch.PortIDs[port] != switchportID { // Don't send out source interface

--- a/user_settings.go
+++ b/user_settings.go
@@ -102,7 +102,7 @@ func resetProgramSettings() {
 }
 
 func resetProgramPrompt() {
-	fmt.Printf("\nAre you sure you want do delete all settings, achievements, and saved networks? [y/n]: ")
+	fmt.Printf("\nAre you sure you want do delete all settings, Achievements, and saved networks? [y/n]: ")
 	scanner.Scan()
 	confirmation := scanner.Text()
 	confirmation = strings.ToUpper(confirmation)

--- a/user_settings.go
+++ b/user_settings.go
@@ -15,11 +15,11 @@ import (
 )
 
 type Settings struct {
-	ID           string `json:"id"`
-	Author       string `json:"author"`
-	Challenges   []Host `json:"challenges"`
-	ChallengesOn bool   `json:"challenges_on"`
-	ProgramVer   string `json:"program_ver"`
+	ID             string              `json:"id"`
+	Author         string              `json:"author"`
+	Achievements   map[int]Achievement `json:"achievements"`
+	AchievementsOn bool                `json:"achievements_on"`
+	ProgramVer     string              `json:"program_ver"`
 }
 
 var user_settings Settings
@@ -34,8 +34,10 @@ func loadUserSettings() {
 		os.Create(filename)
 
 		settings := Settings{
-			ID:     idgen(8),
-			Author: "",
+			ID:             idgen(8),
+			Author:         "",
+			Achievements:   make(map[int]Achievement),
+			AchievementsOn: true,
 		}
 		user_settings = settings
 		saveUserSettings()
@@ -60,6 +62,8 @@ func loadUserSettings() {
 	}
 
 	user_settings = settings_obj
+
+	buildAchievementCatalog()
 }
 
 func saveUserSettings() {
@@ -85,16 +89,20 @@ func changeSettingsName() {
 	saveUserSettings()
 }
 
-func toggleChallenges() {}
+func toggleAchievements() {}
 
-func resetChallenges() {}
+func resetAchievements() {
+	user_settings.Achievements = make(map[int]Achievement)
+	saveUserSettings()
+	fmt.Println("Achievements have been reset")
+}
 
 func resetProgramSettings() {
 	os.Remove("saves/user_settings.json")
 }
 
 func resetProgramPrompt() {
-	fmt.Printf("\nAre you sure you want do delete all settings, challenges, and saved networks? [y/n]: ")
+	fmt.Printf("\nAre you sure you want do delete all settings, achievements, and saved networks? [y/n]: ")
 	scanner.Scan()
 	confirmation := scanner.Text()
 	confirmation = strings.ToUpper(confirmation)

--- a/user_settings.go
+++ b/user_settings.go
@@ -1,0 +1,105 @@
+/*
+File:		user_settings.go
+Author: 	https://github.com/vincebel7
+Purpose:	User-wide settings
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+type Settings struct {
+	ID           string `json:"id"`
+	Author       string `json:"author"`
+	Challenges   []Host `json:"challenges"`
+	ChallengesOn bool   `json:"challenges_on"`
+	ProgramVer   string `json:"program_ver"`
+}
+
+var user_settings Settings
+
+func loadUserSettings() {
+	filename := "saves/user_settings.json"
+
+	// Check if file exists
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		// File doesn't exist, create it
+		os.Create(filename)
+
+		settings := Settings{
+			ID:     idgen(8),
+			Author: "",
+		}
+		user_settings = settings
+		saveUserSettings()
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		fmt.Printf("1File not found: %s", filename)
+	}
+
+	b1 := make([]byte, 1000000) //TODO: secure this
+	n1, err := f.Read(b1)
+
+	if err != nil {
+		fmt.Printf("1File not found: %s", filename)
+	}
+
+	//unmarshal
+	var settings_obj Settings
+	err = json.Unmarshal(b1[:n1], &settings_obj)
+	if err != nil {
+		fmt.Printf("err: %v", err)
+	}
+
+	user_settings = settings_obj
+}
+
+func saveUserSettings() {
+	marshString, err := json.Marshal(user_settings)
+	if err != nil {
+		log.Println(err)
+	}
+	//Write to file
+	filename := "saves/user_settings.json"
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0660)
+	if err != nil {
+		log.Fatal(err)
+	}
+	f.Write(marshString)
+	os.Truncate(filename, int64(len(marshString)))
+}
+
+func changeSettingsName() {
+	fmt.Print("\nPlease enter your name: ")
+	scanner.Scan()
+	username := scanner.Text()
+	user_settings.Author = username
+	saveUserSettings()
+}
+
+func toggleChallenges() {}
+
+func resetChallenges() {}
+
+func resetProgramSettings() {
+	os.Remove("saves/user_settings.json")
+}
+
+func resetProgramPrompt() {
+	fmt.Printf("\nAre you sure you want do delete all settings, challenges, and saved networks? [y/n]: ")
+	scanner.Scan()
+	confirmation := scanner.Text()
+	confirmation = strings.ToUpper(confirmation)
+	if confirmation == "Y" {
+		resetProgramSettings()
+		//TODO: Wipe saves
+	}
+}


### PR DESCRIPTION
Features/Improvements:

- Achievements: Complete tasks in your network to earn achievements.
- Devices now cache ARP results in a local ARP table
- Switches now cache MAC:Interface mappings in a local MAC address table
- ARP tables and MAC address tables can be manually cleared out
- File versioning: If you try to load a savefile made in a previous version of ltdnet, the program will warn you and offer the option to attempt a savefile migration to the current version.
- User Preferences: User can change settings about their program, and reset their data
- Switches now flood frames if MAC mapping unknown, instead of shortcutting to the destination channel
- License `ltdnet` under GNU GPLv3

Bugfixes:

- Error-checking on new network names to prevent duplicate network names or a blank network name