### PR TITLE
v0.3.1 - Switching improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Clears the /saves directory
 ## Version History
 What has been accomplished at each version
 
-### v0.3.1 - ? 2024
-Switch fixes: Better broadcast handling, improved ARP + MAC tables
+### v0.3.1 - October 29, 2024
+Switch fixes: Hosts can link to switches, better broadcast handling, improved ARP + MAC tables
 
 ### v0.3.0 - October 26, 2024
 User Achievements, ARP table, switch MAC address tables, user preferences

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Clears the /saves directory
 ## Version History
 What has been accomplished at each version
 
+### v0.3.1 - ? 2024
+Switch fixes: Better broadcast handling, improved ARP + MAC tables
+
 ### v0.3.0 - October 26, 2024
 User Achievements, ARP table, switch MAC address tables, user preferences
 

--- a/USER-MANUAL
+++ b/USER-MANUAL
@@ -47,7 +47,20 @@ The PC, host1, is not connected to the router. Let's link them together:
 Now you're connected! 
 
 
-## Networking
-Instructions coming soon. Why not use the "help" command to see how to connect to your new PC?
+## About routers, virtual switches
+
+In networking, routers are devices that route between two networks. In ltdnet, routing isn't a feature yet, and there is only one network.
+
+Your first router, the Bobcat 100, is a 2-in-1 device: a little home router with a built-in switch. In ltdnet, this is known as a *virtual switch*. 
+
+You might notice with the "show network overview" command that your host1 now uplinks to router1, but technically it's connected to the built-in virtual switch, shown in parentheses to the right. It might look something like (V-2f109f30). You can control this switch like any other switch, such as:
+
+> control switch V-2f109f30
+
+The Bobcat 100 also runs its own DHCP server. Explore the "help" command to learn how to use it.
+
+
+## Conclusion
+More instructions coming soon. Why not use the "help" command to see how to connect to your new PC?
 
 Also, if you're a completionist or just need something to do, ltdnet has Achievements. Try "achievements" for more info.

--- a/USER-MANUAL
+++ b/USER-MANUAL
@@ -1,6 +1,6 @@
 ===============
 ltdnet manual
-v0.3.0
+v0.3.1
 ===============
 
 Welcome to ltdnet! Using this program, you can simulate a LAN (Local Area Network) with virtual computers, switches, and routers. ltdnet features fictional device models, such as the ProBox, a state-of-the-art PC workstation, and the Bobcat 100, a sturdy small business router (with no recurring license fees!).

--- a/actions.go
+++ b/actions.go
@@ -589,15 +589,19 @@ func hostDetermineDstMAC(srcHost Host, dstIP string, useTable bool) string {
 		debug(4, "hostDetermineDstMAC", srcID, "Sending to same subnet, about to ARP table lookup or ARP")
 
 		// Check ARP table
-		if useTable && snet.Hosts[getHostIndexFromID(srcID)].ARPTable[dstIP] != "" {
-			dstMAC = snet.Hosts[getHostIndexFromID(srcID)].ARPTable[dstIP]
+		if useTable && snet.Hosts[getHostIndexFromID(srcID)].ARPTable[dstIP].MACAddr != "" {
+			dstMAC = snet.Hosts[getHostIndexFromID(srcID)].ARPTable[dstIP].MACAddr
 		} else {
 			// ARP request
 			dstMAC = arp_request(srcID, dstIP)
 			if dstMAC == "TIMEOUT" { // ARP did not return a MAC
 				fmt.Printf("ARP request timed out.\n")
 			} else {
-				snet.Hosts[getHostIndexFromID(srcID)].ARPTable[dstIP] = dstMAC // Add to ARP table
+				arpEntry := ARPEntry{
+					MACAddr:   dstMAC,
+					Interface: snet.Hosts[getHostIndexFromID(srcID)].UplinkID,
+				}
+				snet.Hosts[getHostIndexFromID(srcID)].ARPTable[dstIP] = arpEntry // Add to ARP table
 			}
 		}
 
@@ -606,15 +610,19 @@ func hostDetermineDstMAC(srcHost Host, dstIP string, useTable bool) string {
 		gateway := srcHost.DefaultGateway.String()
 
 		// Check ARP table
-		if snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway] != "" {
-			dstMAC = snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway]
+		if snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway].MACAddr != "" {
+			dstMAC = snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway].MACAddr
 		} else {
 			// ARP request
 			dstMAC = arp_request(srcID, gateway)
 			if dstMAC == "TIMEOUT" { // ARP did not return a MAC
 				fmt.Printf("ARP request timed out.\n")
 			} else {
-				snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway] = dstMAC // Add to ARP table
+				arpEntry := ARPEntry{
+					MACAddr:   dstMAC,
+					Interface: snet.Hosts[getHostIndexFromID(srcID)].UplinkID,
+				}
+				snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway] = arpEntry // Add to ARP table
 			}
 		}
 	}
@@ -633,15 +641,19 @@ func routerDetermineDstMAC(router Router, dstIP string, useTable bool) string {
 		debug(4, "routerDetermineDstMAC", router.ID, "Sending to same subnet, about to MAC table lookup or ARP")
 
 		// Check ARP table
-		if useTable && snet.Router.ARPTable[dstIP] != "" {
-			dstMAC = snet.Router.ARPTable[dstIP]
+		if useTable && snet.Router.ARPTable[dstIP].MACAddr != "" {
+			dstMAC = snet.Router.ARPTable[dstIP].MACAddr
 		} else {
 			// ARP request
 			dstMAC = arp_request(router.ID, dstIP)
 			if dstMAC == "TIMEOUT" { // ARP did not return a MAC
 				fmt.Printf("ARP request timed out.\n")
 			} else {
-				snet.Router.ARPTable[dstIP] = dstMAC // Add to ARP table
+				arpEntry := ARPEntry{
+					MACAddr:   dstMAC,
+					Interface: router.LANLinkID,
+				}
+				snet.Router.ARPTable[dstIP] = arpEntry // Add to ARP table
 			}
 		}
 

--- a/actions.go
+++ b/actions.go
@@ -214,6 +214,7 @@ func arp_request(srcID string, targetIP string) string {
 	// Send frame and wait for ARPREPLY
 	channels[linkID] <- arpRequestFrameBytes
 	debug(2, "arp_request", srcID, "ARPREQUEST sent")
+	debug(4, "arp_request", srcID, "ARPREQUEST sent - linkid: "+linkID)
 
 	sockets := socketMaps[srcID]
 	socketID := "arp_" + string(targetIP)

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-var currentVersion = "v0.3.0"
+var currentVersion = "v0.3.1"
 
 func intro() {
 	fmt.Println("ltdnet " + currentVersion)
@@ -170,7 +170,7 @@ func actionsMenu() {
 				confirmation := scanner.Text()
 				confirmation = strings.ToUpper(confirmation)
 				if confirmation == "Y" {
-					delSwitch()
+					delSwitch(actionword3)
 					save()
 				}
 			}
@@ -193,10 +193,13 @@ func actionsMenu() {
 
 	case "link":
 		if (actionword2 == "host") && (actionword3 != "") && (actionword4 != "") {
-			linkHost(actionword3, actionword4)
+			linkHostTo(actionword3, actionword4)
+			save()
+		} else if (actionword2 == "switch") && (actionword3 != "") && (actionword4 != "") {
+			linkSwitchTo(actionword3, actionword4)
 			save()
 		} else {
-			fmt.Println(" Usage: link host <hostname> <router_hostname>")
+			fmt.Println(" Usage: link <host|switch> <hostname> <router_hostname>")
 		}
 
 	case "unlink":

--- a/client.go
+++ b/client.go
@@ -343,7 +343,7 @@ func main() {
 		<-listenSync
 	}
 	fmt.Printf("\n[Notice] Debug level is set to %d\n", getDebug())
-	fmt.Printf("[Notice] Please note that switch functionality is limited and in development\n")
+	fmt.Printf("[Notice] Please note that switches can't yet link to routers or other switches.\n")
 
 	fmt.Println("\nltdnetOS:")
 

--- a/client_test.go
+++ b/client_test.go
@@ -61,5 +61,13 @@ func TestNetworkSetup(t *testing.T) {
 		t.Errorf("DHCP failed for host")
 	}
 
+	// Test 5: Switching
+	addSwitch("s1")
+	addHost("h5")
+	addHost("h6")
+
+	linkHostTo("h5", "s1")
+	linkHostTo("h6", "s1")
+
 	cleanTestSaves()
 }

--- a/client_test.go
+++ b/client_test.go
@@ -40,9 +40,9 @@ func TestNetworkSetup(t *testing.T) {
 	}
 
 	// Test 3: Link hosts
-	linkHost("h1", "r1")
-	linkHost("h2", "r1")
-	linkHost("h3", "r1")
+	linkHostTo("h1", "r1")
+	linkHostTo("h2", "r1")
+	linkHostTo("h3", "r1")
 
 	if (snet.Hosts[0].UplinkID == "") || (snet.Router.VSwitch.Ports[1] == "") {
 		t.Errorf("Host not (properly) linked")

--- a/connhost.go
+++ b/connhost.go
@@ -145,7 +145,7 @@ func HostConn(device string, id string) {
 						}
 
 					case "clear":
-						snet.Hosts[getHostIndexFromID(host.ID)].ARPTable = make(map[string]string)
+						snet.Hosts[getHostIndexFromID(host.ID)].ARPTable = make(map[string]ARPEntry)
 						fmt.Println("ARP table cleared")
 
 					case "help", "?":

--- a/connhost.go
+++ b/connhost.go
@@ -151,7 +151,7 @@ func HostConn(device string, id string) {
 					case "help", "?":
 						fmt.Println("",
 							"arp\t\t\tShows the device's ARP table (IP address : MAC address)\n",
-							"arp request <dst_ip>\tManually ARP request an address",
+							"arp request <dst_ip>\tManually ARP request an address\n",
 							"arp clear\t\tClears the device's ARP table",
 						)
 

--- a/connrouter.go
+++ b/connrouter.go
@@ -120,7 +120,7 @@ func RouterConn(device string, id string) {
 						}
 
 					case "clear":
-						snet.Router.ARPTable = make(map[string]string)
+						snet.Router.ARPTable = make(map[string]ARPEntry)
 						fmt.Println("ARP table cleared")
 
 					case "help", "?":

--- a/connswitch.go
+++ b/connswitch.go
@@ -76,9 +76,9 @@ func SwitchConn(id string) {
 					switch action[1] {
 					case "clear":
 						if snet.Router.VSwitch.ID == id {
-							snet.Router.VSwitch.MACTable = make(map[string]int)
+							snet.Router.VSwitch.MACTable = make(map[string]MACEntry)
 						} else {
-							snet.Switches[getSwitchIndexFromID(id)].MACTable = make(map[string]int)
+							snet.Switches[getSwitchIndexFromID(id)].MACTable = make(map[string]MACEntry)
 						}
 						fmt.Println("MAC table cleared")
 

--- a/display.go
+++ b/display.go
@@ -307,7 +307,7 @@ func displayARPTable(deviceID string) {
 }
 
 func displayMACTable(deviceID string) {
-	var MACTable map[string]int
+	var MACTable map[string]MACEntry
 
 	if snet.Router.VSwitch.ID == deviceID {
 		MACTable = snet.Router.VSwitch.MACTable
@@ -316,10 +316,10 @@ func displayMACTable(deviceID string) {
 	}
 
 	fmt.Printf("MAC Table:\n")
-	fmt.Printf("MAC Address\t\tInterface #\n")
+	fmt.Printf("MAC Address\t\tInterface\t\tExpiration\n")
 
 	for i := range MACTable {
-		fmt.Printf("%s\t%d\n", i, MACTable[i])
+		fmt.Printf("%s\t%d\n", i, MACTable[i].Interface)
 	}
 	fmt.Printf("\n")
 }

--- a/display.go
+++ b/display.go
@@ -289,7 +289,7 @@ func show(hostname string) {
 }
 
 func displayARPTable(deviceID string) {
-	var ARPTable map[string]string
+	var ARPTable map[string]ARPEntry
 
 	if snet.Router.ID == deviceID {
 		ARPTable = snet.Router.ARPTable
@@ -298,10 +298,10 @@ func displayARPTable(deviceID string) {
 	}
 
 	fmt.Printf("ARP Table:\n")
-	fmt.Printf("IP Address\t\tMAC Address\n")
+	fmt.Printf("IP Address\t\tMAC Address\t\tInterface\t\tExpiration\n")
 
 	for i := range ARPTable {
-		fmt.Printf("%s\t\t%s\n", i, ARPTable[i])
+		fmt.Printf("%s\t\t%s\t%s\n", i, ARPTable[i].MACAddr, ARPTable[i].Interface)
 	}
 	fmt.Printf("\n")
 }

--- a/display.go
+++ b/display.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 )
 
 /* DIAGRAMMING */
@@ -16,7 +17,9 @@ func drawDiagram(rootID string) {
 	drawDiagramAction(rootID, "")
 
 	//Unlinked switches
-	// drawDiagramConnected(switch ID)
+	for i := range snet.Switches {
+		drawDiagramAction(snet.Switches[i].ID, "switch")
+	}
 
 	// Unlinked hosts
 	for i := range snet.Hosts {
@@ -35,14 +38,22 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 		rootType = "router"
 	}
 
-	if rootType == "" {
+	if rootType == "switch" {
 		for i := range snet.Switches {
 			if rootID == snet.Switches[i].ID {
 				rootHostname = snet.Switches[i].Hostname
 				rootType = "switch"
 				//rootIndex = i
+				drawSwitch(snet.Switches[i].ID)
+
+				for j := range snet.Switches[i].Ports {
+					if snet.Switches[i].Ports[j] != "" {
+						drawConnectedHost(snet.Switches[i].Ports[j], j, snet.Switches[i])
+					}
+				}
 			}
 		}
+
 	}
 
 	if rootType == "" {
@@ -63,7 +74,7 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 
 		for i := range snet.Router.VSwitch.Ports {
 			if snet.Router.VSwitch.Ports[i] != "" && i != 0 {
-				drawConnectedHost(snet.Router.VSwitch.Ports[i], i)
+				drawConnectedHost(snet.Router.VSwitch.Ports[i], i, snet.Router.VSwitch)
 			}
 		}
 	}
@@ -97,6 +108,47 @@ func drawRouter() {
 	fmt.Println("|\n|------------------------|")
 }
 
+func drawSwitch(id string) {
+	sw := snet.Switches[getSwitchIndexFromID(id)]
+
+	connectedPorts := 0
+	for i := range sw.Ports {
+		if sw.Ports[i] != "" {
+			connectedPorts++
+		}
+	}
+
+	space1 := 13 - len(sw.Hostname)
+	space2 := 11 - len(strconv.Itoa(len(sw.Ports)))
+	space3 := 5
+	space4 := 16 - len(sw.Model)
+
+	fmt.Println("")
+	fmt.Println("|------------------------|")
+	fmt.Println("|          Switch        |")
+	fmt.Printf("| Hostname: %s", sw.Hostname)
+	for i := 0; i < space1; i++ {
+		fmt.Printf(" ")
+	}
+	fmt.Printf("|\n")
+	fmt.Printf("| Port count: %d", len(sw.Ports))
+	for i := 0; i < space2; i++ {
+		fmt.Printf(" ")
+	}
+	fmt.Printf("|\n")
+	fmt.Printf("| Connected ports: %d", connectedPorts)
+	for i := 0; i < space3; i++ {
+		fmt.Printf(" ")
+	}
+	fmt.Printf("|\n")
+	fmt.Printf("| Model: %s", sw.Model)
+	for i := 0; i < space4; i++ {
+		fmt.Printf(" ")
+	}
+	fmt.Printf("|\n")
+	fmt.Println("|------------------------|")
+}
+
 func drawHost(id string) {
 	h := snet.Hosts[getHostIndexFromID(id)]
 
@@ -125,7 +177,7 @@ func drawHost(id string) {
 	fmt.Println("|------------------------|")
 }
 
-func drawConnectedHost(id string, iter int) {
+func drawConnectedHost(id string, iter int, sw Switch) {
 	h := snet.Hosts[getHostIndexFromID(id)]
 
 	space1 := 13 - len(h.Hostname)
@@ -146,7 +198,7 @@ func drawConnectedHost(id string, iter int) {
 	}
 	fmt.Printf("|\n")
 
-	if iter == getActivePorts(snet.Router.VSwitch)-1 {
+	if iter == getActivePorts(sw)-1 {
 		fmt.Printf("                    | Model: %s", h.Model)
 	} else {
 		fmt.Printf("            ||      | Model: %s", h.Model)
@@ -155,7 +207,7 @@ func drawConnectedHost(id string, iter int) {
 		fmt.Printf(" ")
 	}
 	fmt.Printf("|\n")
-	if iter == getActivePorts(snet.Router.VSwitch)-1 {
+	if iter == getActivePorts(sw)-1 {
 		fmt.Println("                    |------------------------|")
 	} else {
 		fmt.Println("            ||      |------------------------|")

--- a/helpers.go
+++ b/helpers.go
@@ -197,7 +197,17 @@ func removeHostFromSlice(s []Host, i int) []Host {
 	return s[:len(s)-1]
 }
 
+func removeSwitchFromSlice(s []Switch, i int) []Switch {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
+}
+
 func removeStringFromSlice(s []string, i int) []string {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
+}
+
+func removeIntFromSlice(s []int, i int) []int {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]
 }

--- a/helpers.go
+++ b/helpers.go
@@ -18,21 +18,21 @@ func idgen(n int) string {
 	var idchars = []rune("abcdef1234567890")
 	id := make([]rune, n)
 
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := range id {
-		id[i] = idchars[rand.Intn(len(idchars))]
+		id[i] = idchars[r.Intn(len(idchars))]
 	}
 
 	return string(id)
 }
 
 func idgen_int(n int) int {
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	firstDigit := rand.Intn(9) + 1
+	firstDigit := r.Intn(9) + 1
 	numberStr := strconv.Itoa(firstDigit)
 	for i := 1; i < n; i++ {
-		digit := rand.Intn(10)
+		digit := r.Intn(10)
 		numberStr += strconv.Itoa(digit)
 	}
 	result, _ := strconv.Atoi(numberStr)
@@ -118,16 +118,6 @@ func getSwitchIDFromLink(link string) string {
 	return s.ID
 }
 
-func getMACfromID(id string) string {
-	//Router
-	if id == snet.Router.ID {
-		return snet.Router.MACAddr
-	}
-
-	//Hosts
-	return snet.Hosts[getHostIndexFromID(id)].MACAddr
-}
-
 func getIDfromMAC(mac string) string {
 	//Router
 	if mac == snet.Router.MACAddr {
@@ -198,16 +188,6 @@ func removeHostFromSlice(s []Host, i int) []Host {
 }
 
 func removeSwitchFromSlice(s []Switch, i int) []Switch {
-	s[i] = s[len(s)-1]
-	return s[:len(s)-1]
-}
-
-func removeStringFromSlice(s []string, i int) []string {
-	s[i] = s[len(s)-1]
-	return s[:len(s)-1]
-}
-
-func removeIntFromSlice(s []int, i int) []int {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]
 }

--- a/host.go
+++ b/host.go
@@ -10,18 +10,26 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 )
 
 type Host struct {
-	ID             string            `json:"id"`
-	Model          string            `json:"model"`
-	MACAddr        string            `json:"macaddr"`
-	Hostname       string            `json:"hostname"`
-	IPAddr         net.IP            `json:"ipaddr"`
-	SubnetMask     string            `json:"mask"`
-	DefaultGateway net.IP            `json:"gateway"`
-	UplinkID       string            `json:"uplinkid"`
-	ARPTable       map[string]string `json:"arptable"`
+	ID             string              `json:"id"`
+	Model          string              `json:"model"`
+	MACAddr        string              `json:"macaddr"`
+	Hostname       string              `json:"hostname"`
+	IPAddr         net.IP              `json:"ipaddr"`
+	SubnetMask     string              `json:"mask"`
+	DefaultGateway net.IP              `json:"gateway"`
+	UplinkID       string              `json:"uplinkid"`
+	ARPTable       map[string]ARPEntry `json:"arptable"`
+}
+
+type ARPEntry struct {
+	MACAddr    string    `json:"macaddr"`
+	ExpireTime time.Time `json:"expireTime"`
+	Interface  string    `json:"interface"`
+	State      string    `json:"state"`
 }
 
 func NewProbox(hostname string) Host {
@@ -30,7 +38,7 @@ func NewProbox(hostname string) Host {
 	p.Model = "ProBox 1"
 	p.MACAddr = macgen()
 	p.Hostname = hostname
-	p.ARPTable = make(map[string]string)
+	p.ARPTable = make(map[string]ARPEntry)
 
 	return p
 }

--- a/network.go
+++ b/network.go
@@ -244,11 +244,11 @@ func save() {
 func (n *Network) ClearMACTables() {
 	// Host ARP tables
 	for _, host := range n.Hosts {
-		host.ARPTable = make(map[string]string)
+		host.ARPTable = make(map[string]ARPEntry)
 	}
 
 	// Router ARP table
-	n.Router.ARPTable = make(map[string]string)
+	n.Router.ARPTable = make(map[string]ARPEntry)
 
 	// Switch MAC address tables
 	for _, sw := range n.Switches {

--- a/network.go
+++ b/network.go
@@ -243,16 +243,16 @@ func save() {
 
 func (n *Network) ClearMACTables() {
 	// Host ARP tables
-	for _, host := range n.Hosts {
-		host.ARPTable = make(map[string]ARPEntry)
+	for i := range n.Hosts {
+		n.Hosts[i].ARPTable = make(map[string]ARPEntry)
 	}
 
 	// Router ARP table
 	n.Router.ARPTable = make(map[string]ARPEntry)
 
 	// Switch MAC address tables
-	for _, sw := range n.Switches {
-		sw.MACTable = make(map[string]MACEntry)
+	for i := range n.Switches {
+		n.Switches[i].MACTable = make(map[string]MACEntry)
 	}
 
 	// VSwitch MAC address table

--- a/network.go
+++ b/network.go
@@ -252,9 +252,9 @@ func (n *Network) ClearMACTables() {
 
 	// Switch MAC address tables
 	for _, sw := range n.Switches {
-		sw.MACTable = make(map[string]int)
+		sw.MACTable = make(map[string]MACEntry)
 	}
 
 	// VSwitch MAC address table
-	n.Router.VSwitch.MACTable = make(map[string]int)
+	n.Router.VSwitch.MACTable = make(map[string]MACEntry)
 }

--- a/router.go
+++ b/router.go
@@ -16,14 +16,15 @@ import (
 )
 
 type Router struct {
-	ID       string            `json:"id"`
-	Model    string            `json:"model"`
-	MACAddr  string            `json:"macaddr"` // LAN-facing interface
-	Hostname string            `json:"hostname"`
-	Gateway  net.IP            `json:"gateway"`
-	VSwitch  Switch            `json:"vswitchid"` // Virtual built-in switch to router
-	DHCPPool DHCPPool          `json:"dhcp_pool"` // Instance of DHCPPool
-	ARPTable map[string]string `json:"arptable"`
+	ID        string            `json:"id"`
+	Model     string            `json:"model"`
+	MACAddr   string            `json:"macaddr"` // LAN-facing interface
+	Hostname  string            `json:"hostname"`
+	Gateway   net.IP            `json:"gateway"`
+	VSwitch   Switch            `json:"vswitchid"` // Virtual built-in switch to router
+	DHCPPool  DHCPPool          `json:"dhcp_pool"` // Instance of DHCPPool
+	ARPTable  map[string]string `json:"arptable"`
+	LANLinkID string            `json:"lanlinkid"` // link ID for its LAN connection
 }
 
 type DHCPPool struct {
@@ -115,6 +116,8 @@ func addRouter(routerHostname string, routerModel string) {
 	snet.Router = r
 
 	assignSwitchport(snet.Router.VSwitch, snet.Router.ID)
+
+	snet.Router.LANLinkID = snet.Router.VSwitch.PortIDs[0]
 
 	generateRouterChannels()
 	go listenRouterChannel()

--- a/router.go
+++ b/router.go
@@ -122,7 +122,7 @@ func addRouter(routerHostname string, routerModel string) {
 	generateRouterChannels()
 	go listenRouterChannel()
 	for i := 0; i < getActivePorts(snet.Router.VSwitch); i++ {
-		go listenSwitchportChannel(snet.Router.VSwitch.PortIDs[i])
+		go listenSwitchportChannel(snet.Router.VSwitch.ID, snet.Router.VSwitch.PortIDs[i])
 	}
 	achievementTester(ROUTINE_BUSINESS)
 }

--- a/router.go
+++ b/router.go
@@ -16,15 +16,15 @@ import (
 )
 
 type Router struct {
-	ID        string            `json:"id"`
-	Model     string            `json:"model"`
-	MACAddr   string            `json:"macaddr"` // LAN-facing interface
-	Hostname  string            `json:"hostname"`
-	Gateway   net.IP            `json:"gateway"`
-	VSwitch   Switch            `json:"vswitchid"` // Virtual built-in switch to router
-	DHCPPool  DHCPPool          `json:"dhcp_pool"` // Instance of DHCPPool
-	ARPTable  map[string]string `json:"arptable"`
-	LANLinkID string            `json:"lanlinkid"` // link ID for its LAN connection
+	ID        string              `json:"id"`
+	Model     string              `json:"model"`
+	MACAddr   string              `json:"macaddr"` // LAN-facing interface
+	Hostname  string              `json:"hostname"`
+	Gateway   net.IP              `json:"gateway"`
+	VSwitch   Switch              `json:"vswitchid"` // Virtual built-in switch to router
+	DHCPPool  DHCPPool            `json:"dhcp_pool"` // Instance of DHCPPool
+	ARPTable  map[string]ARPEntry `json:"arptable"`
+	LANLinkID string              `json:"lanlinkid"` // link ID for its LAN connection
 }
 
 type DHCPPool struct {
@@ -51,7 +51,7 @@ func NewBobcat(hostname string) Router {
 	bobcat.Model = "Bobcat 100"
 	bobcat.MACAddr = macgen()
 	bobcat.Hostname = hostname
-	bobcat.ARPTable = make(map[string]string)
+	bobcat.ARPTable = make(map[string]ARPEntry)
 
 	vSwitch := addVirtualSwitch(BOBCAT_PORTS)
 	bobcat.VSwitch = vSwitch
@@ -65,7 +65,7 @@ func NewOsiris(hostname string) Router {
 	osiris.Model = "Osiris 2-I"
 	osiris.MACAddr = macgen()
 	osiris.Hostname = hostname
-	osiris.ARPTable = make(map[string]string)
+	osiris.ARPTable = make(map[string]ARPEntry)
 
 	vSwitch := addVirtualSwitch(OSIRIS_PORTS)
 	osiris.VSwitch = vSwitch

--- a/switch.go
+++ b/switch.go
@@ -23,7 +23,6 @@ type Switch struct {
 	Maxports int                 `json:"maxports"`
 	Ports    []string            `json:"ports"`   // maps port # to downlink ID
 	PortIDs  []string            `json:"portids"` // maps port # to Port ID
-	//PortMACs []string       `json:"portmacs"` // maps port # to interface MAC address
 	ARPTable map[string]ARPEntry `json:"arptable"`
 }
 

--- a/switch.go
+++ b/switch.go
@@ -220,8 +220,12 @@ func switchforward(frame Frame, switchportID string) {
 
 	outboundPort := lookupMACTable(dstMAC, switchportID)
 
-	if outboundPort == -1 { // No matching port for this MAC address was found in the MAC address table.
+	if dstMAC == "ff:ff:ff:ff:ff:ff" { // Broadcast
 		floodFrame = true
+		debug(4, "switchforward", snet.Router.VSwitch.ID, "L2 Broadcast. Flooding frame on all ports")
+	} else if outboundPort == -1 { // No matching port for this MAC address was found in the MAC address table
+		floodFrame = true
+		debug(4, "switchforward", snet.Router.VSwitch.ID, "Destination address not found in MAC table. Flooding frame on all ports")
 	} else {
 		if isSwitchportID(snet.Router.VSwitch, switchportID) {
 			debug(4, "switchforward", snet.Router.VSwitch.ID, "Destination address found in MAC table.")
@@ -247,7 +251,6 @@ func switchforward(frame Frame, switchportID string) {
 	outFrame, _ := json.Marshal(f)
 
 	if floodFrame {
-		debug(4, "switchforward", snet.Router.VSwitch.ID, "Destination address not found in MAC table. Flooding frame on all ports")
 		for port := range snet.Router.VSwitch.Ports {
 			linkID = snet.Router.VSwitch.Ports[port]
 			if snet.Router.VSwitch.PortIDs[port] != switchportID { // Don't send out source interface

--- a/switch.go
+++ b/switch.go
@@ -80,7 +80,7 @@ func addSwitch(switchHostname string) {
 		socketMaps[s.PortIDs[j]] = make(map[string]chan Frame)
 		actionsync[s.PortIDs[j]] = make(chan int)
 
-		go listenSwitchportChannel(s.PortIDs[j])
+		go listenSwitchportChannel(s.ID, s.PortIDs[j])
 	}
 }
 
@@ -106,8 +106,97 @@ func addVirtualSwitch(maxports int) Switch {
 	return v
 }
 
-func delSwitch() {
+func delSwitch(hostname string) {
 	//TODO For all linked devices, unlink. then delete
+	hostname = strings.ToUpper(hostname)
+	//search for switch
+	for i := range snet.Switches {
+		if strings.ToUpper(snet.Switches[i].Hostname) == hostname {
+			// Unlink all devices connected to this switch
+			for j := range snet.Switches[i].Ports {
+				if snet.Switches[i].Ports[j] != "" {
+					// Unlink if host
+					for h := range snet.Hosts {
+						if snet.Hosts[h].ID == snet.Switches[i].Ports[j] {
+							snet.Hosts[h].UplinkID = ""
+						}
+					}
+
+					// Unlink if switch - TODO
+				}
+			}
+
+			snet.Switches = removeSwitchFromSlice(snet.Switches, i)
+			fmt.Printf("\nSwitch deleted\n")
+			return
+		}
+	}
+	fmt.Printf("\nSwitch %s was not deleted.\n", hostname)
+}
+
+func linkSwitchTo(localDevice string, remoteDevice string) {
+	localDevice = strings.ToUpper(localDevice)
+	remoteDevice = strings.ToUpper(remoteDevice)
+
+	//Make sure there's enough ports - if uplink device is a router
+	if remoteDevice == strings.ToUpper(snet.Router.Hostname) {
+		if getActivePorts(snet.Router.VSwitch) >= snet.Router.VSwitch.Maxports {
+			fmt.Printf("No available ports - %s only has %d ports\n", snet.Router.Model, snet.Router.VSwitch.Maxports)
+			return
+		}
+	}
+
+	//Make sure there's enough ports - if uplink device is a switch
+	for s := range snet.Switches {
+		if remoteDevice == strings.ToUpper(snet.Switches[s].Hostname) {
+			if getActivePorts(snet.Switches[s]) >= snet.Switches[s].Maxports {
+				fmt.Printf("No available ports - %s only has %d ports\n", snet.Switches[s].Model, snet.Switches[s].Maxports)
+				return
+			}
+		}
+	}
+
+	//find switch with that hostname
+	for i := range snet.Switches {
+		if strings.ToUpper(snet.Switches[i].Hostname) == localDevice {
+			uplinkID := ""
+			//Remote device on new link is the Router
+			if remoteDevice == strings.ToUpper(snet.Router.Hostname) {
+				//find next free port
+				for k := range snet.Router.VSwitch.Ports {
+					if (snet.Router.VSwitch.Ports[k] == "") && (uplinkID == "") {
+						uplinkID = snet.Router.VSwitch.PortIDs[k]
+					}
+				}
+				//uplinkID = snet.Router.VSwitch.ID
+
+				// Assign switchport on remote device
+				assignSwitchport(snet.Router.VSwitch, snet.Hosts[i].ID)
+			} else {
+				//Remote device on the new link is not the Router. Search switches
+				for j := range snet.Switches {
+					if remoteDevice == strings.ToUpper(snet.Switches[j].Hostname) {
+
+						//find next free port
+						for k := range snet.Switches[j].Ports {
+							if (snet.Switches[j].Ports[k] == "") && (uplinkID == "") {
+								uplinkID = snet.Switches[j].PortIDs[k]
+
+								// Assign switchport on remote device
+								assignSwitchport(snet.Switches[j], snet.Switches[i].ID)
+							}
+						}
+
+					}
+				}
+			}
+
+			// Assign switchport on local switch
+			assignSwitchport(snet.Switches[i], "TEST")
+
+			return
+		}
+	}
 }
 
 func lookupMACTable(dstMAC string, switchportID string) int { // For looking up addresses
@@ -220,12 +309,12 @@ func assignSwitchport(sw Switch, id string) Switch {
 
 	channels[sw.PortIDs[portIndex]] = make(chan json.RawMessage)
 	debug(4, "assignSwitchport", sw.PortIDs[portIndex], "listening for id")
-	go listenSwitchportChannel(sw.PortIDs[portIndex])
+	go listenSwitchportChannel(sw.ID, sw.PortIDs[portIndex])
 
 	return sw
 }
 
-func switchforward(frame Frame, switchportID string) {
+func switchforward(frame Frame, switchID string, switchportID string) {
 	srcMAC := frame.SrcMAC
 	dstMAC := frame.DstMAC
 	linkID := ""
@@ -235,19 +324,18 @@ func switchforward(frame Frame, switchportID string) {
 
 	if dstMAC == "ff:ff:ff:ff:ff:ff" { // Broadcast
 		floodFrame = true
-		debug(4, "switchforward", snet.Router.VSwitch.ID, "L2 Broadcast. Flooding frame on all ports")
+		debug(4, "switchforward", switchID, "L2 Broadcast. Flooding frame on all ports")
 	} else if outboundPort == -1 { // No matching port for this MAC address was found in the MAC address table
 		floodFrame = true
-		debug(4, "switchforward", snet.Router.VSwitch.ID, "Destination address not found in MAC table. Flooding frame on all ports")
+		debug(4, "switchforward", switchID, "Destination address not found in MAC table. Flooding frame on all ports")
 	} else {
-		if isSwitchportID(snet.Router.VSwitch, switchportID) {
-			debug(4, "switchforward", snet.Router.VSwitch.ID, "Destination address found in MAC table.")
+		if isSwitchportID(snet.Router.VSwitch, switchportID) { // VSwitch
+			debug(4, "switchforward", switchID, "Destination address found in MAC table.")
 			linkID = snet.Router.VSwitch.Ports[outboundPort]
-		} else {
-			debug(3, "switchforward", switchportID, "Should never print this yet - outer")
+		} else { // Regular switch
 			for i := range snet.Switches {
-				debug(3, "switchforward", switchportID, "Should never print this yet - inner")
 				if isSwitchportID(snet.Switches[i], switchportID) {
+					debug(4, "switchforward", switchID, "Destination address found in MAC table.")
 					linkID = snet.Switches[i].Ports[outboundPort]
 				}
 			}
@@ -264,10 +352,20 @@ func switchforward(frame Frame, switchportID string) {
 	outFrame, _ := json.Marshal(f)
 
 	if floodFrame {
-		for port := range snet.Router.VSwitch.Ports {
-			linkID = snet.Router.VSwitch.Ports[port]
-			if snet.Router.VSwitch.PortIDs[port] != switchportID { // Don't send out source interface
-				channels[linkID] <- outFrame
+		if isSwitchportID(snet.Router.VSwitch, switchportID) { // VSwitch
+			for port := range snet.Router.VSwitch.Ports {
+				linkID = snet.Router.VSwitch.Ports[port]
+				if (snet.Router.VSwitch.PortIDs[port] != switchportID) && (snet.Router.VSwitch.PortIDs[port] != "") { // Don't send out source interface
+					channels[linkID] <- outFrame
+				}
+			}
+		} else { // Regular switch
+			switchIndex := getSwitchIndexFromID(switchID)
+			for port := range snet.Switches[switchIndex].Ports {
+				linkID = snet.Switches[switchIndex].Ports[port]
+				if (snet.Switches[switchIndex].PortIDs[port] != switchportID) && (snet.Switches[switchIndex].PortIDs[port] != "") { // Don't send out source interface
+					channels[linkID] <- outFrame
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Features/Improvements:

- Hosts can now link to switches (switches cannot link to other switches, or routers)
- Broadcasts now traverse the network properly, instead of the "cheat" way with a single broadcast channel.
- ARP tables and MAC address tables are structs, preparing to offer support to table entry timeouts, just like how real ARP tables and MAC address tables work.

Known bugs remaining:

- Can't ping/ARP self. Internal networking to be added in the near future
- DHCP messages that don't receive a response just hang. Need to implement timeouts/retries similar to ARP/ping
- Deleting devices causes weird behavior when printing diagrams. Low-priority
- It's possible to add devices with duplicate hostnames, causing multiple errors