### PR TITLE
v0.3.2 - Bugfixing, rework switch links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 saves/user_saves/*.json
 saves/user_settings.json
+bin/

--- a/README.md
+++ b/README.md
@@ -53,15 +53,21 @@ Simple run script to run *.go
 ### wipesaves.sh
 Clears the /saves directory
 
-## Known bugs
-- Save files may break with newer versions (Future fix: No breaking changes in minor versions)
+## Known bugs (highest to lowest impact)
+- Switches can't yet connect to routers, or other switches
 
-- Resetting user settings puts program into errored state. (Temporary fix: Restart program)
+- Can't ping yourself (This will be fixed with proper interfaces in v0.4)
 
-- Hosts ARP for their own MAC address (Low priority)
+- Hosts ARP for their own MAC address (No adverse impact, just needless traffic)
+
+- Save files may break with newer versions (Future fix: No breaking changes in minor versions after v1.0)
+
 
 ## Version History
 What has been accomplished at each version
+
+### v0.3.2 - November 1, 2024
+Bugfixes, rework local and remote ends of switchport links
 
 ### v0.3.1 - October 29, 2024
 Switch fixes: Hosts can link to switches, better broadcast handling, improved ARP + MAC tables

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 A little CLI-based network simulator for learning networking concepts, utilizing lightweight goroutines and channels for network traffic.
 Includes fictional network appliances and simple implementations of essential TCP/IP protocols.
 
-## How to run
+## How to run (binary)
+Download the Windows or Linux executable binary from the [Releases](https://github.com/vincebel7/ltdnet/releases) page
+
+## How to run (from source)
 1. Install Go (https://golang.org/doc/install)
 2. Clone this repository and enter the directory
 3. Make the run script executable, and execute it (./run.sh)

--- a/achievements.go
+++ b/achievements.go
@@ -10,12 +10,16 @@ Action-based: Achievements given when a particular action occurs (successful pin
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 type Achievement struct {
 	ID          int    `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Hint        string `json:"hint"`
 	ProgramVer  string `json:"program_ver"`
 }
 
@@ -31,6 +35,7 @@ func buildAchievementCatalog() {
 		ID:          ROUTINE_BUSINESS,
 		Name:        "Route-ine Business",
 		Description: "Add a router to your network.",
+		Hint:        "Have you tried the 'add router' command?",
 	}
 	AchievementCatalog[ROUTINE_BUSINESS] = achievement
 
@@ -38,6 +43,7 @@ func buildAchievementCatalog() {
 		ID:          UNITED_PINGDOM,
 		Name:        "United Pingdom",
 		Description: "Successfully ping from one device to another.",
+		Hint:        "Control a host and ping your default gateway, see if you get a response.",
 	}
 	AchievementCatalog[UNITED_PINGDOM] = achievement
 
@@ -45,6 +51,7 @@ func buildAchievementCatalog() {
 		ID:          ARP_HOT,
 		Name:        "ARP It Like It's Hot",
 		Description: "Manually send an ARP request, and receive a reply.",
+		Hint:        "ARP is how hosts find out other MAC addresses on their network. Try 'arp ?' from a host.",
 	}
 	AchievementCatalog[ARP_HOT] = achievement
 }
@@ -66,11 +73,36 @@ func displayAchievements() {
 		unlockedChar := "."
 
 		if _, exists := user_settings.Achievements[i]; exists {
-			unlockedChar = "Y"
+			unlockedChar = "Yes"
 		}
 
 		fmt.Printf("%d\t%s\t%s\t%s\n", AchievementCatalog[i].ID, PadRight(AchievementCatalog[i].Name, 25), PadRight(AchievementCatalog[i].Description, 50), unlockedChar)
 	}
+}
+
+func printAchievementsExplanation() {
+	fmt.Println("Achievements are a fun way to learn how to use ltdnet, and learn networking concepts. Use the achievement commands to guide what you try next. 'achievements show' will list all the achievements and whether you've earned it or not. 'achievements info <#>' will give you a hint about how to unlock an achievement.")
+}
+
+func printAchievementInfo(achieveStr string) {
+	achievement := Achievement{}
+	achievementFound := false
+	achieveNum, _ := strconv.Atoi(achieveStr)
+	for a := range AchievementCatalog {
+		if AchievementCatalog[a].ID == achieveNum {
+			achievement = AchievementCatalog[a]
+			achievementFound = true
+		}
+	}
+
+	if !achievementFound {
+		fmt.Printf("No achievement \"%s\" found. Usage: achievements info <#>\n", achieveStr)
+		return
+	}
+
+	fmt.Printf("Achievement #%d: %s\n", achievement.ID, achievement.Name)
+	fmt.Printf("Description: %s\n", achievement.Description)
+	fmt.Printf("Hint: %s\n", achievement.Hint)
 }
 
 func achievementAward(achievement Achievement) {

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Create the bin directory if it doesn't exist
+mkdir -p bin
+
+# Build for Linux
+echo "Building ltdnet for Linux..."
+GOOS=linux GOARCH=amd64 go build -o bin/ltdnet-linux
+if [ $? -eq 0 ]; then
+    echo "Linux build successful: bin/ltdnet-linux"
+else
+    echo "Linux build failed"
+    exit 1
+fi
+
+# Build for Windows
+echo "Building ltdnet for Windows..."
+GOOS=windows GOARCH=amd64 go build -o bin/ltdnet.exe
+if [ $? -eq 0 ]; then
+    echo "Windows build successful: bin/ltdnet.exe"
+else
+    echo "Windows build failed"
+    exit 1
+fi
+
+echo "Build complete. Executables are in the bin directory."

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-var currentVersion = "v0.3.1"
+var currentVersion = "v0.3.2"
 
 func intro() {
 	fmt.Println("ltdnet " + currentVersion)
@@ -52,7 +52,7 @@ func startMenu() bool {
 			selection = true
 			preferencesMenu()
 		default:
-			fmt.Println("Not a valid option. Options: 1, 2, 3")
+			fmt.Println("Not a valid option. Options: 1, 2, 3, 4")
 		}
 	}
 
@@ -89,7 +89,7 @@ func preferencesMenu() {
 			resetProgramSettings()
 		case "5":
 			selection = true
-			resetProgramPrompt()
+			resetAllPrompt()
 		default:
 			fmt.Println("Not a valid option. Options: 1, 2, 3, 4, 5")
 		}

--- a/client.go
+++ b/client.go
@@ -246,9 +246,21 @@ func actionsMenu() {
 		case "achievements show":
 			displayAchievements()
 		case "achievements info":
+
 			fmt.Println("Not implemented yet")
+		case "achievements explain":
+			printAchievementsExplanation()
 		default:
-			fmt.Println(" Invalid command. Type 'achievements ?' for a list of commands.")
+			if actionword2 == "info" {
+				if actionword3 != "" {
+					//achieveNum, _ := strconv.Atoi(actionword3)
+					printAchievementInfo(actionword3)
+				} else {
+					fmt.Println("usage: achievements info <#>")
+				}
+			} else {
+				fmt.Println(" Invalid command. Type 'achievements ?' for a list of commands.")
+			}
 		}
 
 	case "save":

--- a/client_test.go
+++ b/client_test.go
@@ -44,7 +44,7 @@ func TestNetworkSetup(t *testing.T) {
 	linkHostTo("h2", "r1")
 	linkHostTo("h3", "r1")
 
-	if (snet.Hosts[0].UplinkID == "") || (snet.Router.VSwitch.PortIDs[1] == "") {
+	if (snet.Hosts[0].UplinkID == "") || (snet.Router.VSwitch.PortLinksRemote[1] == "") {
 		t.Errorf("Host not (properly) linked")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -44,7 +44,7 @@ func TestNetworkSetup(t *testing.T) {
 	linkHostTo("h2", "r1")
 	linkHostTo("h3", "r1")
 
-	if (snet.Hosts[0].UplinkID == "") || (snet.Router.VSwitch.Ports[1] == "") {
+	if (snet.Hosts[0].UplinkID == "") || (snet.Router.VSwitch.PortIDs[1] == "") {
 		t.Errorf("Host not (properly) linked")
 	}
 

--- a/display.go
+++ b/display.go
@@ -46,9 +46,9 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 				//rootIndex = i
 				drawSwitch(snet.Switches[i].ID)
 
-				for j := range snet.Switches[i].Ports {
-					if snet.Switches[i].Ports[j] != "" {
-						drawConnectedHost(snet.Switches[i].Ports[j], j, snet.Switches[i])
+				for j := range snet.Switches[i].PortLinksRemote {
+					if snet.Switches[i].PortLinksRemote[j] != "" {
+						drawConnectedHost(snet.Switches[i].PortLinksRemote[j], j, snet.Switches[i])
 					}
 				}
 			}
@@ -72,9 +72,9 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 			drawRouter()
 		}
 
-		for i := range snet.Router.VSwitch.Ports {
-			if snet.Router.VSwitch.Ports[i] != "" && i != 0 {
-				drawConnectedHost(snet.Router.VSwitch.Ports[i], i, snet.Router.VSwitch)
+		for i := range snet.Router.VSwitch.PortLinksRemote {
+			if snet.Router.VSwitch.PortLinksRemote[i] != "" && i != 0 {
+				drawConnectedHost(snet.Router.VSwitch.PortLinksRemote[i], i, snet.Router.VSwitch)
 			}
 		}
 	}
@@ -112,14 +112,14 @@ func drawSwitch(id string) {
 	sw := snet.Switches[getSwitchIndexFromID(id)]
 
 	connectedPorts := 0
-	for i := range sw.Ports {
-		if sw.Ports[i] != "" {
+	for i := range sw.PortLinksRemote {
+		if sw.PortLinksRemote[i] != "" {
 			connectedPorts++
 		}
 	}
 
 	space1 := 13 - len(sw.Hostname)
-	space2 := 11 - len(strconv.Itoa(len(sw.PortIDs)))
+	space2 := 11 - len(strconv.Itoa(len(sw.PortLinksLocal)))
 	space3 := 5
 	space4 := 16 - len(sw.Model)
 
@@ -131,7 +131,7 @@ func drawSwitch(id string) {
 		fmt.Printf(" ")
 	}
 	fmt.Printf("|\n")
-	fmt.Printf("| Port count: %d", len(sw.PortIDs))
+	fmt.Printf("| Port count: %d", len(sw.PortLinksLocal))
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}

--- a/display.go
+++ b/display.go
@@ -112,14 +112,14 @@ func drawSwitch(id string) {
 	sw := snet.Switches[getSwitchIndexFromID(id)]
 
 	connectedPorts := 0
-	for i := range sw.Ports {
-		if sw.Ports[i] != "" {
+	for i := range sw.PortIDs {
+		if sw.PortIDs[i] != "" {
 			connectedPorts++
 		}
 	}
 
 	space1 := 13 - len(sw.Hostname)
-	space2 := 11 - len(strconv.Itoa(len(sw.Ports)))
+	space2 := 11 - len(strconv.Itoa(len(sw.PortIDs)))
 	space3 := 5
 	space4 := 16 - len(sw.Model)
 

--- a/display.go
+++ b/display.go
@@ -112,8 +112,8 @@ func drawSwitch(id string) {
 	sw := snet.Switches[getSwitchIndexFromID(id)]
 
 	connectedPorts := 0
-	for i := range sw.PortIDs {
-		if sw.PortIDs[i] != "" {
+	for i := range sw.Ports {
+		if sw.Ports[i] != "" {
 			connectedPorts++
 		}
 	}
@@ -131,7 +131,7 @@ func drawSwitch(id string) {
 		fmt.Printf(" ")
 	}
 	fmt.Printf("|\n")
-	fmt.Printf("| Port count: %d", len(sw.Ports))
+	fmt.Printf("| Port count: %d", len(sw.PortIDs))
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -147,21 +148,23 @@ func dynamic_assign(id string, ipaddr net.IP, defaultgateway net.IP, subnetmask 
 }
 
 func hostname_exists(hostname string) bool {
-	if snet.Router.Hostname == hostname {
+	hostname = strings.ToUpper(hostname)
+
+	if strings.ToUpper(snet.Router.Hostname) == hostname {
 		return true
 	}
-	if snet.Router.VSwitch.Hostname == hostname {
+	if strings.ToUpper(snet.Router.VSwitch.Hostname) == hostname {
 		return true
 	}
 
 	for s := range snet.Switches {
-		if snet.Switches[s].Hostname == hostname {
+		if strings.ToUpper(snet.Switches[s].Hostname) == hostname {
 			return true
 		}
 	}
 
 	for h := range snet.Hosts {
-		if snet.Hosts[h].Hostname == hostname {
+		if strings.ToUpper(snet.Hosts[h].Hostname) == hostname {
 			return true
 		}
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -76,6 +76,15 @@ func getHostIndexFromID(id string) int {
 	return -1
 }
 
+func getHostIndexFromLinkID(id string) int {
+	for h := range snet.Hosts {
+		if snet.Hosts[h].UplinkID == id {
+			return h
+		}
+	}
+	return -1
+}
+
 func getSwitchIndexFromID(id string) int {
 	for s := range snet.Switches {
 		if snet.Switches[s].ID == id {

--- a/helpers.go
+++ b/helpers.go
@@ -103,8 +103,8 @@ func getSwitchportIDFromLink(link string) int {
 		s = snet.Switches[getSwitchIndexFromID(switchID)]
 	}
 
-	for i := range s.PortIDs {
-		if s.PortIDs[i] == link {
+	for i := range s.PortLinksLocal {
+		if s.PortLinksLocal[i] == link {
 			return i
 		}
 	}

--- a/host.go
+++ b/host.go
@@ -98,25 +98,17 @@ func linkHostTo(localDevice string, remoteDevice string) {
 			//Remote device on new link is the Router
 			if remoteDevice == strings.ToUpper(snet.Router.Hostname) {
 				//find next free port
-				for k := range snet.Router.VSwitch.Ports {
-					if (snet.Router.VSwitch.Ports[k] == "") && (uplinkID == "") {
-						uplinkID = snet.Router.VSwitch.PortIDs[k]
-						assignSwitchport(snet.Router.VSwitch, snet.Hosts[i].ID)
-					}
-				}
+				portIndex := assignSwitchport(snet.Router.VSwitch, snet.Hosts[i].ID)
+				uplinkID = snet.Router.VSwitch.PortLinksLocal[portIndex]
 
 			} else {
 				//Remote device on the new link is not the Router. Search switches
 				for j := range snet.Switches {
 					if remoteDevice == strings.ToUpper(snet.Switches[j].Hostname) {
-
 						//find next free port
-						for k := range snet.Switches[j].Ports {
-							if (snet.Switches[j].Ports[k] == "") && (uplinkID == "") {
-								uplinkID = snet.Switches[j].PortIDs[k]
-								assignSwitchport(snet.Switches[j], snet.Hosts[i].ID)
-							}
-						}
+						portIndex := assignSwitchport(snet.Switches[j], snet.Hosts[i].ID)
+						uplinkID = snet.Switches[j].PortLinksLocal[portIndex]
+
 					}
 				}
 			}
@@ -150,10 +142,9 @@ func delHost(hostname string) {
 	for i := range snet.Hosts {
 		if strings.ToUpper(snet.Hosts[i].Hostname) == hostname {
 			//unlink, Vswitch
-			for j := range snet.Router.VSwitch.Ports {
-				if snet.Router.VSwitch.PortIDs[j] == snet.Hosts[i].UplinkID {
-					snet.Router.VSwitch.Ports[j] = ""
-					snet.Router.VSwitch.PortIDs[j] = ""
+			for j := range snet.Router.VSwitch.PortLinksRemote {
+				if snet.Router.VSwitch.PortLinksLocal[j] == snet.Hosts[i].UplinkID {
+					snet.Router.VSwitch.PortLinksRemote[j] = ""
 
 					snet.Hosts = removeHostFromSlice(snet.Hosts, i)
 					fmt.Printf("\nHost deleted\n")
@@ -163,10 +154,9 @@ func delHost(hostname string) {
 
 			//unlink, other switches
 			for sw := range snet.Switches {
-				for p := range snet.Switches[sw].Ports {
-					if snet.Switches[sw].PortIDs[p] == snet.Hosts[i].UplinkID {
-						snet.Switches[sw].Ports[p] = ""
-						snet.Switches[sw].PortIDs[p] = ""
+				for p := range snet.Switches[sw].PortLinksRemote {
+					if snet.Switches[sw].PortLinksLocal[p] == snet.Hosts[i].UplinkID {
+						snet.Switches[sw].PortLinksRemote[p] = ""
 
 						snet.Hosts = removeHostFromSlice(snet.Hosts, i)
 						fmt.Printf("\nHost deleted\n")

--- a/host.go
+++ b/host.go
@@ -138,7 +138,6 @@ func unlinkHost(hostname string) {
 			//next, remove the host's uplink (host-end unlink)
 			uplinkID := ""
 			snet.Hosts[i].UplinkID = uplinkID
-			//snet.Router.Ports = removeStringFromSlice(snet.Router.Ports, i)
 
 			return
 		}
@@ -152,7 +151,7 @@ func delHost(hostname string) {
 		if strings.ToUpper(snet.Hosts[i].Hostname) == hostname {
 			//unlink, Vswitch
 			for j := range snet.Router.VSwitch.Ports {
-				if snet.Router.VSwitch.Ports[j] == snet.Hosts[i].ID {
+				if snet.Router.VSwitch.PortIDs[j] == snet.Hosts[i].UplinkID {
 					snet.Router.VSwitch.Ports[j] = ""
 					snet.Router.VSwitch.PortIDs[j] = ""
 
@@ -165,7 +164,7 @@ func delHost(hostname string) {
 			//unlink, other switches
 			for sw := range snet.Switches {
 				for p := range snet.Switches[sw].Ports {
-					if snet.Switches[sw].Ports[p] == snet.Hosts[i].ID {
+					if snet.Switches[sw].PortIDs[p] == snet.Hosts[i].UplinkID {
 						snet.Switches[sw].Ports[p] = ""
 						snet.Switches[sw].PortIDs[p] = ""
 

--- a/listener.go
+++ b/listener.go
@@ -32,13 +32,13 @@ func Listener() {
 		go listenRouterChannel()
 
 		for i := 0; i < getActivePorts(snet.Router.VSwitch); i++ {
-			go listenSwitchportChannel(snet.Router.VSwitch.ID, snet.Router.VSwitch.PortIDs[i])
+			go listenSwitchportChannel(snet.Router.VSwitch.ID, snet.Router.VSwitch.PortLinksLocal[i])
 		}
 	}
 
 	for i := range snet.Switches {
 		for j := 0; j < getActivePorts(snet.Switches[i]); j++ {
-			go listenSwitchportChannel(snet.Switches[i].ID, snet.Switches[i].PortIDs[j])
+			go listenSwitchportChannel(snet.Switches[i].ID, snet.Switches[i].PortLinksLocal[j])
 		}
 	}
 
@@ -56,9 +56,9 @@ func generateHostChannels(i int) {
 
 func generateSwitchChannels(i int) {
 	for j := 0; j < getActivePorts(snet.Switches[i]); j++ {
-		channels[snet.Switches[i].PortIDs[j]] = make(chan json.RawMessage)
-		socketMaps[snet.Switches[i].PortIDs[j]] = make(map[string]chan Frame)
-		actionsync[snet.Switches[i].PortIDs[j]] = make(chan int)
+		channels[snet.Switches[i].PortLinksLocal[j]] = make(chan json.RawMessage)
+		socketMaps[snet.Switches[i].PortLinksLocal[j]] = make(map[string]chan Frame)
+		actionsync[snet.Switches[i].PortLinksLocal[j]] = make(chan int)
 	}
 }
 
@@ -68,8 +68,8 @@ func generateRouterChannels() {
 		socketMaps[snet.Router.ID] = make(map[string]chan Frame)
 
 		for i := 0; i < getActivePorts(snet.Router.VSwitch); i++ {
-			channels[snet.Router.VSwitch.PortIDs[i]] = make(chan json.RawMessage)
-			socketMaps[snet.Router.VSwitch.PortIDs[i]] = make(map[string]chan Frame)
+			channels[snet.Router.VSwitch.PortLinksLocal[i]] = make(chan json.RawMessage)
+			socketMaps[snet.Router.VSwitch.PortLinksLocal[i]] = make(map[string]chan Frame)
 			actionsync[snet.Router.ID] = make(chan int)
 		}
 	}

--- a/router.go
+++ b/router.go
@@ -117,12 +117,12 @@ func addRouter(routerHostname string, routerModel string) {
 
 	assignSwitchport(snet.Router.VSwitch, snet.Router.ID)
 
-	snet.Router.LANLinkID = snet.Router.VSwitch.PortIDs[0]
+	snet.Router.LANLinkID = snet.Router.VSwitch.PortLinksLocal[0]
 
 	generateRouterChannels()
 	go listenRouterChannel()
 	for i := 0; i < getActivePorts(snet.Router.VSwitch); i++ {
-		go listenSwitchportChannel(snet.Router.VSwitch.ID, snet.Router.VSwitch.PortIDs[i])
+		go listenSwitchportChannel(snet.Router.VSwitch.ID, snet.Router.VSwitch.PortLinksLocal[i])
 	}
 	achievementTester(ROUTINE_BUSINESS)
 }

--- a/switch.go
+++ b/switch.go
@@ -112,11 +112,11 @@ func delSwitch(hostname string) {
 	for i := range snet.Switches {
 		if strings.ToUpper(snet.Switches[i].Hostname) == hostname {
 			// Unlink all devices connected to this switch
-			for j := range snet.Switches[i].Ports {
-				if snet.Switches[i].Ports[j] != "" {
+			for j := range snet.Switches[i].PortIDs {
+				if snet.Switches[i].PortIDs[j] != "" {
 					// Unlink if host
 					for h := range snet.Hosts {
-						if snet.Hosts[h].ID == snet.Switches[i].Ports[j] {
+						if snet.Hosts[h].UplinkID == snet.Switches[i].PortIDs[j] {
 							snet.Hosts[h].UplinkID = ""
 						}
 					}
@@ -162,8 +162,8 @@ func linkSwitchTo(localDevice string, remoteDevice string) {
 			//Remote device on new link is the Router
 			if remoteDevice == strings.ToUpper(snet.Router.Hostname) {
 				//find next free port
-				for k := range snet.Router.VSwitch.Ports {
-					if (snet.Router.VSwitch.Ports[k] == "") && (uplinkID == "") {
+				for k := range snet.Router.VSwitch.PortIDs {
+					if (snet.Router.VSwitch.PortIDs[k] == "") && (uplinkID == "") {
 						uplinkID = snet.Router.VSwitch.PortIDs[k]
 					}
 				}
@@ -177,8 +177,8 @@ func linkSwitchTo(localDevice string, remoteDevice string) {
 					if remoteDevice == strings.ToUpper(snet.Switches[j].Hostname) {
 
 						//find next free port
-						for k := range snet.Switches[j].Ports {
-							if (snet.Switches[j].Ports[k] == "") && (uplinkID == "") {
+						for k := range snet.Switches[j].PortIDs {
+							if (snet.Switches[j].PortIDs[k] == "") && (uplinkID == "") {
 								uplinkID = snet.Switches[j].PortIDs[k]
 
 								// Assign switchport on remote device
@@ -378,9 +378,12 @@ func freeSwitchport(link string) {
 	switchID := getSwitchIDFromLink(link)
 
 	if snet.Router.VSwitch.ID == switchID {
+		snet.Router.VSwitch.PortIDs[switchport] = ""
 		snet.Router.VSwitch.Ports[switchport] = ""
 	} else {
 		i := getSwitchIndexFromID(switchID)
+		snet.Switches[i].PortIDs[switchport] = ""
 		snet.Switches[i].Ports[switchport] = ""
 	}
+
 }

--- a/switch.go
+++ b/switch.go
@@ -15,15 +15,15 @@ import (
 )
 
 type Switch struct {
-	ID       string              `json:"id"`
-	Model    string              `json:"model"`
-	Hostname string              `json:"hostname"`
-	MgmtIP   net.IP              `json:"mgmtip"`
-	MACTable map[string]MACEntry `json:"mactable"`
-	Maxports int                 `json:"maxports"`
-	Ports    []string            `json:"ports"`   // maps port # to downlink ID
-	PortIDs  []string            `json:"portids"` // maps port # to Port ID
-	ARPTable map[string]ARPEntry `json:"arptable"`
+	ID              string              `json:"id"`
+	Model           string              `json:"model"`
+	Hostname        string              `json:"hostname"`
+	MgmtIP          net.IP              `json:"mgmtip"`
+	MACTable        map[string]MACEntry `json:"mactable"`
+	Maxports        int                 `json:"maxports"`
+	PortLinksRemote []string            `json:"links_remote"` // maps port # to remote link ID
+	PortLinksLocal  []string            `json:"links_local"`  // maps port # to local link ID
+	ARPTable        map[string]ARPEntry `json:"arptable"`
 }
 
 type MACEntry struct {
@@ -60,14 +60,14 @@ func addSwitch(switchHostname string) {
 		return
 	}
 
-	s.PortIDs = make([]string, s.Maxports)
-	for i := range s.PortIDs {
-		s.PortIDs[i] = idgen(8)
+	s.PortLinksLocal = make([]string, s.Maxports)
+	for i := range s.PortLinksLocal {
+		s.PortLinksLocal[i] = idgen(8)
 	}
 
-	s.Ports = make([]string, s.Maxports)
-	for i := range s.Ports {
-		s.Ports[i] = ""
+	s.PortLinksRemote = make([]string, s.Maxports)
+	for i := range s.PortLinksRemote {
+		s.PortLinksRemote[i] = ""
 	}
 
 	s.MACTable = make(map[string]MACEntry)
@@ -75,11 +75,11 @@ func addSwitch(switchHostname string) {
 
 	generateSwitchChannels(getSwitchIndexFromID(s.ID))
 	for j := 0; j < getActivePorts(s); j++ {
-		channels[s.PortIDs[j]] = make(chan json.RawMessage)
-		socketMaps[s.PortIDs[j]] = make(map[string]chan Frame)
-		actionsync[s.PortIDs[j]] = make(chan int)
+		channels[s.PortLinksLocal[j]] = make(chan json.RawMessage)
+		socketMaps[s.PortLinksLocal[j]] = make(map[string]chan Frame)
+		actionsync[s.PortLinksLocal[j]] = make(chan int)
 
-		go listenSwitchportChannel(s.ID, s.PortIDs[j])
+		go listenSwitchportChannel(s.ID, s.PortLinksLocal[j])
 	}
 }
 
@@ -90,14 +90,14 @@ func addVirtualSwitch(maxports int) Switch {
 	v.Hostname = "V-" + v.ID
 	v.Maxports = maxports
 
-	v.PortIDs = make([]string, v.Maxports)
-	for i := range v.PortIDs {
-		v.PortIDs[i] = idgen(8)
+	v.PortLinksLocal = make([]string, v.Maxports)
+	for i := range v.PortLinksLocal {
+		v.PortLinksLocal[i] = idgen(8)
 	}
 
-	v.Ports = make([]string, v.Maxports)
-	for i := range v.Ports {
-		v.Ports[i] = ""
+	v.PortLinksRemote = make([]string, v.Maxports)
+	for i := range v.PortLinksRemote {
+		v.PortLinksRemote[i] = ""
 	}
 
 	v.MACTable = make(map[string]MACEntry)
@@ -112,11 +112,11 @@ func delSwitch(hostname string) {
 	for i := range snet.Switches {
 		if strings.ToUpper(snet.Switches[i].Hostname) == hostname {
 			// Unlink all devices connected to this switch
-			for j := range snet.Switches[i].PortIDs {
-				if snet.Switches[i].Ports[j] != "" {
+			for j := range snet.Switches[i].PortLinksLocal {
+				if snet.Switches[i].PortLinksRemote[j] != "" {
 					// Unlink if host
 					for h := range snet.Hosts {
-						if snet.Hosts[h].UplinkID == snet.Switches[i].PortIDs[j] {
+						if snet.Hosts[h].UplinkID == snet.Switches[i].PortLinksLocal[j] {
 							snet.Hosts[h].UplinkID = ""
 						}
 					}
@@ -162,9 +162,9 @@ func linkSwitchTo(localDevice string, remoteDevice string) {
 			//Remote device on new link is the Router
 			if remoteDevice == strings.ToUpper(snet.Router.Hostname) {
 				//find next free port
-				for k := range snet.Router.VSwitch.PortIDs {
-					if (snet.Router.VSwitch.PortIDs[k] == "") && (uplinkID == "") {
-						uplinkID = snet.Router.VSwitch.PortIDs[k]
+				for k := range snet.Router.VSwitch.PortLinksLocal {
+					if (snet.Router.VSwitch.PortLinksRemote[k] == "") && (uplinkID == "") {
+						uplinkID = snet.Router.VSwitch.PortLinksLocal[k]
 					}
 				}
 				//uplinkID = snet.Router.VSwitch.ID
@@ -177,9 +177,9 @@ func linkSwitchTo(localDevice string, remoteDevice string) {
 					if remoteDevice == strings.ToUpper(snet.Switches[j].Hostname) {
 
 						//find next free port
-						for k := range snet.Switches[j].PortIDs {
-							if (snet.Switches[j].PortIDs[k] == "") && (uplinkID == "") {
-								uplinkID = snet.Switches[j].PortIDs[k]
+						for k := range snet.Switches[j].PortLinksLocal {
+							if (snet.Switches[j].PortLinksRemote[k] == "") && (uplinkID == "") {
+								uplinkID = snet.Switches[j].PortLinksLocal[k]
 
 								// Assign switchport on remote device
 								assignSwitchport(snet.Switches[j], snet.Switches[i].ID)
@@ -275,8 +275,8 @@ func delMACEntry(macaddr string, id string, port int) {
 }
 
 func isSwitchportID(sw Switch, id string) bool {
-	for i := range sw.PortIDs {
-		if sw.PortIDs[i] == id {
+	for i := range sw.PortLinksLocal {
+		if sw.PortLinksLocal[i] == id {
 			return true
 		}
 	}
@@ -287,8 +287,8 @@ func isSwitchportID(sw Switch, id string) bool {
 func getActivePorts(sw Switch) int {
 	count := 0
 
-	for i := range sw.Ports {
-		if sw.Ports[i] != "" {
+	for i := range sw.PortLinksRemote {
+		if sw.PortLinksRemote[i] != "" {
 			count++
 		}
 	}
@@ -296,21 +296,21 @@ func getActivePorts(sw Switch) int {
 	return count
 }
 
-func assignSwitchport(sw Switch, id string) Switch {
+func assignSwitchport(sw Switch, id string) int {
 	portIndex := -1
-	for i := range sw.Ports {
-		if sw.Ports[i] == "" {
-			sw.Ports[i] = id
+	for i := range sw.PortLinksRemote {
+		if sw.PortLinksRemote[i] == "" {
+			sw.PortLinksRemote[i] = id
 			portIndex = i
 			break
 		}
 	}
 
-	channels[sw.PortIDs[portIndex]] = make(chan json.RawMessage)
-	debug(4, "assignSwitchport", sw.PortIDs[portIndex], "listening for id")
-	go listenSwitchportChannel(sw.ID, sw.PortIDs[portIndex])
+	channels[sw.PortLinksLocal[portIndex]] = make(chan json.RawMessage)
+	debug(4, "assignSwitchport", sw.PortLinksLocal[portIndex], "listening for id")
+	go listenSwitchportChannel(sw.ID, sw.PortLinksLocal[portIndex])
 
-	return sw
+	return portIndex
 }
 
 func switchforward(frame Frame, switchID string, switchportID string) {
@@ -330,12 +330,12 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 	} else {
 		if isSwitchportID(snet.Router.VSwitch, switchportID) { // VSwitch
 			debug(4, "switchforward", switchID, "Destination address found in MAC table.")
-			linkID = snet.Router.VSwitch.Ports[outboundPort]
+			linkID = snet.Router.VSwitch.PortLinksRemote[outboundPort]
 		} else { // Regular switch
 			for i := range snet.Switches {
 				if isSwitchportID(snet.Switches[i], switchportID) {
 					debug(4, "switchforward", switchID, "Destination address found in MAC table.")
-					linkID = snet.Switches[i].Ports[outboundPort]
+					linkID = snet.Switches[i].PortLinksRemote[outboundPort]
 				}
 			}
 		}
@@ -352,17 +352,19 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 
 	if floodFrame {
 		if isSwitchportID(snet.Router.VSwitch, switchportID) { // VSwitch
-			for port := range snet.Router.VSwitch.Ports {
-				linkID = snet.Router.VSwitch.Ports[port]
-				if (snet.Router.VSwitch.PortIDs[port] != switchportID) && (snet.Router.VSwitch.Ports[port] != "") { // Don't send out source interface
+			for port := range snet.Router.VSwitch.PortLinksRemote {
+				linkID = snet.Router.VSwitch.PortLinksRemote[port]
+				// Don't send out source interface, or unplugged ports
+				if (snet.Router.VSwitch.PortLinksLocal[port] != switchportID) && (linkID != "") {
 					channels[linkID] <- outFrame
 				}
 			}
 		} else { // Regular switch
 			switchIndex := getSwitchIndexFromID(switchID)
-			for port := range snet.Switches[switchIndex].Ports {
-				linkID = snet.Switches[switchIndex].Ports[port]
-				if (snet.Switches[switchIndex].PortIDs[port] != switchportID) && (snet.Switches[switchIndex].Ports[port] != "") { // Don't send out source interface
+			for port := range snet.Switches[switchIndex].PortLinksRemote {
+				linkID = snet.Switches[switchIndex].PortLinksRemote[port]
+				// Don't send out source interface, or unplugged ports
+				if (snet.Switches[switchIndex].PortLinksLocal[port] != switchportID) && (linkID != "") {
 					channels[linkID] <- outFrame
 				}
 			}
@@ -378,12 +380,10 @@ func freeSwitchport(link string) {
 	switchID := getSwitchIDFromLink(link)
 
 	if snet.Router.VSwitch.ID == switchID {
-		snet.Router.VSwitch.PortIDs[switchport] = ""
-		snet.Router.VSwitch.Ports[switchport] = ""
+		snet.Router.VSwitch.PortLinksRemote[switchport] = ""
 	} else {
 		i := getSwitchIndexFromID(switchID)
-		snet.Switches[i].PortIDs[switchport] = ""
-		snet.Switches[i].Ports[switchport] = ""
+		snet.Switches[i].PortLinksRemote[switchport] = ""
 	}
 
 }

--- a/switch.go
+++ b/switch.go
@@ -113,7 +113,7 @@ func delSwitch(hostname string) {
 		if strings.ToUpper(snet.Switches[i].Hostname) == hostname {
 			// Unlink all devices connected to this switch
 			for j := range snet.Switches[i].PortIDs {
-				if snet.Switches[i].PortIDs[j] != "" {
+				if snet.Switches[i].Ports[j] != "" {
 					// Unlink if host
 					for h := range snet.Hosts {
 						if snet.Hosts[h].UplinkID == snet.Switches[i].PortIDs[j] {
@@ -354,7 +354,7 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 		if isSwitchportID(snet.Router.VSwitch, switchportID) { // VSwitch
 			for port := range snet.Router.VSwitch.Ports {
 				linkID = snet.Router.VSwitch.Ports[port]
-				if (snet.Router.VSwitch.PortIDs[port] != switchportID) && (snet.Router.VSwitch.PortIDs[port] != "") { // Don't send out source interface
+				if (snet.Router.VSwitch.PortIDs[port] != switchportID) && (snet.Router.VSwitch.Ports[port] != "") { // Don't send out source interface
 					channels[linkID] <- outFrame
 				}
 			}
@@ -362,7 +362,7 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 			switchIndex := getSwitchIndexFromID(switchID)
 			for port := range snet.Switches[switchIndex].Ports {
 				linkID = snet.Switches[switchIndex].Ports[port]
-				if (snet.Switches[switchIndex].PortIDs[port] != switchportID) && (snet.Switches[switchIndex].PortIDs[port] != "") { // Don't send out source interface
+				if (snet.Switches[switchIndex].PortIDs[port] != switchportID) && (snet.Switches[switchIndex].Ports[port] != "") { // Don't send out source interface
 					channels[linkID] <- outFrame
 				}
 			}

--- a/user_settings.go
+++ b/user_settings.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -44,14 +45,14 @@ func loadUserSettings() {
 	}
 	f, err := os.Open(filename)
 	if err != nil {
-		fmt.Printf("1File not found: %s", filename)
+		fmt.Printf("[Error] File not found: %s", filename)
 	}
 
 	b1 := make([]byte, 1000000) //TODO: secure this
 	n1, err := f.Read(b1)
 
 	if err != nil {
-		fmt.Printf("1File not found: %s", filename)
+		fmt.Printf("[Error] File not found: %s", filename)
 	}
 
 	//unmarshal
@@ -94,20 +95,51 @@ func toggleAchievements() {}
 func resetAchievements() {
 	user_settings.Achievements = make(map[int]Achievement)
 	saveUserSettings()
-	fmt.Println("Achievements have been reset")
+	fmt.Println("[Notice] Achievements have been reset")
 }
 
 func resetProgramSettings() {
 	os.Remove("saves/user_settings.json")
+	fmt.Println("[Notice] User preferences have been reset\n")
+	loadUserSettings()
+	intro()
 }
 
-func resetProgramPrompt() {
+func wipeSaves() {
+	dir := "saves/user_saves"
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Check if the file ends with .json
+		if !info.IsDir() && filepath.Ext(info.Name()) == ".json" {
+			err := os.Remove(path) // Delete the file
+			if err != nil {
+				log.Printf("[Error] Failed to remove file: %s, error: %v", path, err)
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Fatalf("[Error] Error wiping saves: %v", err)
+	} else {
+		fmt.Println("[Notice] Save files have been wiped")
+	}
+}
+
+func resetAllPrompt() {
 	fmt.Printf("\nAre you sure you want do delete all settings, Achievements, and saved networks? [y/n]: ")
 	scanner.Scan()
 	confirmation := scanner.Text()
 	confirmation = strings.ToUpper(confirmation)
+
+	fmt.Printf("\n")
+
 	if confirmation == "Y" {
+		wipeSaves()
+		resetAchievements()
 		resetProgramSettings()
-		//TODO: Wipe saves
 	}
 }

--- a/user_settings.go
+++ b/user_settings.go
@@ -100,7 +100,8 @@ func resetAchievements() {
 
 func resetProgramSettings() {
 	os.Remove("saves/user_settings.json")
-	fmt.Println("[Notice] User preferences have been reset\n")
+	fmt.Println("[Notice] User preferences have been reset")
+	fmt.Println("")
 	loadUserSettings()
 	intro()
 }


### PR DESCRIPTION
Features/Improvements:

- Build script for Windows and Linux releases
- Now uploading binary releases on Github
- More user input validation

Bugfixes:
- Resetting user preferences no longer requires program restart
- Made the switchport's local and remote "ends" for links much less convoluted. Switches now have a map for all their ports' local IDs (permanent), and a map for all their ports' remote IDs (channel to send data to, represented by connected host ID)