### PR TITLE
v0.4.0 - Interfaces, host-level routing, static hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Builds executables for Linux and Windows
 What has been accomplished at each version
 
 ### v0.4.0 - November 2, 2024
-Layer 1 rework (interfaces), frame-sending function, bypasses for self-bound traffic
+Layer 1 rework (interfaces), host-level routing, static hostnames, bypasses for self-bound traffic
 
 ### v0.3.2 - November 1, 2024
 Bugfixes, rework local and remote ends of switchport links

--- a/README.md
+++ b/README.md
@@ -48,26 +48,30 @@ I hope you find this program to be fun. Many more features are on their way, but
 
 For any further questions, please email vincebel@protonmail.com
 
-## Scripts
-
-### run.sh
-Simple run script to run *.go
-
-### wipesaves.sh
-Clears the /saves directory
 
 ## Known bugs (highest to lowest impact)
 - Switches can't yet connect to routers, or other switches
 
-- Can't ping yourself (This will be fixed with proper interfaces in v0.4)
-
-- Hosts ARP for their own MAC address (No adverse impact, just needless traffic)
+- Display functions sometimes cause program to crash if a host has been deleted
 
 - Save files may break with newer versions (Future fix: No breaking changes in minor versions after v1.0)
 
+## Scripts
+
+### run.sh
+Simple run script to run *.go from source
+
+### wipesaves.sh
+Clears the /saves directory
+
+### build.sh
+Builds executables for Linux and Windows
 
 ## Version History
 What has been accomplished at each version
+
+### v0.4.0 - November 2, 2024
+Layer 1 rework (interfaces), frame-sending function, bypasses for self-bound traffic
 
 ### v0.3.2 - November 1, 2024
 Bugfixes, rework local and remote ends of switchport links

--- a/USER-MANUAL
+++ b/USER-MANUAL
@@ -1,6 +1,6 @@
 ===============
 ltdnet manual
-v0.3.1
+v0.4.0
 ===============
 
 Welcome to ltdnet! Using this program, you can simulate a LAN (Local Area Network) with virtual computers, switches, and routers. ltdnet features fictional device models, such as the ProBox, a state-of-the-art PC workstation, and the Bobcat 100, a sturdy small business router (with no recurring license fees!).

--- a/achievements.go
+++ b/achievements.go
@@ -29,6 +29,7 @@ var AchievementCatalog = make(map[int]Achievement)
 var ROUTINE_BUSINESS = 1
 var UNITED_PINGDOM = 2
 var ARP_HOT = 3
+var SNIFF_FRAMES = 4
 
 func buildAchievementCatalog() {
 	achievement := Achievement{
@@ -54,6 +55,14 @@ func buildAchievementCatalog() {
 		Hint:        "ARP is how hosts find out other MAC addresses on their network. Try 'arp ?' from a host.",
 	}
 	AchievementCatalog[ARP_HOT] = achievement
+
+	achievement = Achievement{
+		ID:          SNIFF_FRAMES,
+		Name:        "Sniffing Your Own Frames",
+		Description: "Talk to yourself on localhost",
+		Hint:        "Every host has a loopback interface with an address of 127.0.0.1. Try pinging it.",
+	}
+	AchievementCatalog[SNIFF_FRAMES] = achievement
 }
 
 func displayAchievements() {
@@ -135,6 +144,8 @@ func achievementTester(achievementID int) {
 			achievement2Test()
 		case 3:
 			achievement3Test()
+		case 4:
+			achievement4Test()
 		}
 	}
 }
@@ -153,9 +164,16 @@ func achievement2Test() {
 	achievementAward(achievement)
 }
 
-// Achievement 2: Successful manual ARP request
+// Achievement 3: Successful manual ARP request
 func achievement3Test() {
 	// If this function is called, the achievement is already complete (action-based)
 	achievement := AchievementCatalog[ARP_HOT]
+	achievementAward(achievement)
+}
+
+// Achievement 4: Successful manual ARP request
+func achievement4Test() {
+	// If this function is called, the achievement is already complete (action-based)
+	achievement := AchievementCatalog[SNIFF_FRAMES]
 	achievementAward(achievement)
 }

--- a/achievements.go
+++ b/achievements.go
@@ -43,7 +43,7 @@ func buildAchievementCatalog() {
 	achievement = Achievement{
 		ID:          UNITED_PINGDOM,
 		Name:        "United Pingdom",
-		Description: "Successfully ping from one device to another.",
+		Description: "Successfully ping from one device to another",
 		Hint:        "Control a host and ping your default gateway, see if you get a response.",
 	}
 	AchievementCatalog[UNITED_PINGDOM] = achievement
@@ -51,7 +51,7 @@ func buildAchievementCatalog() {
 	achievement = Achievement{
 		ID:          ARP_HOT,
 		Name:        "ARP It Like It's Hot",
-		Description: "Manually send an ARP request, and receive a reply.",
+		Description: "Manually send an ARP request, and receive a reply",
 		Hint:        "ARP is how hosts find out other MAC addresses on their network. Try 'arp ?' from a host.",
 	}
 	AchievementCatalog[ARP_HOT] = achievement

--- a/actions.go
+++ b/actions.go
@@ -182,6 +182,12 @@ func arp_request(srcID string, targetIP string) string {
 		linkID = snet.Hosts[index].Interface.RemoteL1ID
 	}
 
+	// First, check if it is trying to ARP itself.
+	if targetIP == srcIP {
+		debug(4, "arp_request", srcID, "Destination IP is source IP! Canceling ARP request.")
+		return srcMAC
+	}
+
 	arpRequestMessage := ArpMessage{
 		HTYPE:     1,
 		PTYPE:     "0x800",
@@ -450,10 +456,10 @@ func dhcp_ack(dhcpRequestFrame Frame) {
 			if snet.Router.IsAvailableAddress(dhcpRequestMessage.YIAddr) {
 				messageType = 5
 			} else {
-				debug(1, "dhcp_offer", snet.Router.ID, "Error 4: DHCP address requested is not available")
+				debug(1, "dhcp_offer", snet.Router.ID, "Error: DHCP address requested is not available")
 			}
 		} else {
-			debug(1, "dhcp_offer", snet.Router.ID, "Error 3: Empty DHCP request")
+			debug(1, "dhcp_offer", snet.Router.ID, "Error: Empty DHCP request")
 		}
 	}
 

--- a/actions.go
+++ b/actions.go
@@ -644,3 +644,17 @@ func routerDetermineDstMAC(router Router, dstIP string, useTable bool) string {
 
 	return dstMAC
 }
+
+func resolveHostname(hostname string, dnsTable map[string]DNSEntry) string {
+	// Check local table
+	if entry, found := dnsTable[hostname]; found {
+		if entry.TTL == -1 || time.Since(entry.Timestamp).Seconds() < float64(entry.TTL) {
+			return entry.IPAddress
+		} else {
+			delete(dnsTable, hostname)
+		}
+	}
+
+	// If not found, initiate DNS request
+	return ""
+}

--- a/actions.go
+++ b/actions.go
@@ -124,6 +124,9 @@ func ping(srcID string, dst string, count int) {
 				recvCount++
 				fmt.Printf("Reply from %s: seq=%d\n", dstIP, i)
 				achievementTester(UNITED_PINGDOM)
+				if dstIP == "127.0.0.1" {
+					achievementTester(SNIFF_FRAMES)
+				}
 			} else {
 				debug(1, "ping", srcID, "Error: Out-of-order channel")
 			}
@@ -139,7 +142,8 @@ func ping(srcID string, dst string, count int) {
 
 	// Ping stats
 	fmt.Printf("\nPing statistics for %s:\n", dstIP)
-	fmt.Printf("\tPackets: Sent = %d, Received = %d, Lost = %d (%d%% loss)\n\n", sendCount, recvCount, lossCount, (lossCount / sendCount * 100))
+	fmt.Printf("\tPackets: Sent = %d, Received = %d, Lost = %d (%d%% loss)\n", sendCount, recvCount, lossCount, (lossCount / sendCount * 100))
+	fmt.Printf("\tSource address: %s\n\n", srcIP)
 
 	actionsync[srcID] <- lossCount
 }

--- a/actions.go
+++ b/actions.go
@@ -128,20 +128,13 @@ func pong(srcID string, frame Frame) {
 	srcIP := ""
 	srcMAC := ""
 	dstIP := readIPv4PacketHeader(receivedIpv4Packet.Header).SrcIP
-	dstMAC := frame.SrcMAC // Value only used if it cannot be determined below
+	dstMAC := ""
 
 	if snet.Router.ID == srcID {
 		srcMAC = snet.Router.Interface.MACAddr
 		srcIP = snet.Router.GetIP()
-		dstMAC := routerDetermineDstMAC(snet.Router, dstIP, true)
-
-		//Get link to send ping to
-		dstID := getIDfromMAC(dstMAC)
-		if getHostIndexFromID(dstID) != -1 {
-			linkID = snet.Hosts[getHostIndexFromID(getIDfromMAC(dstMAC))].Interface.RemoteL1ID
-		} else if snet.Router.ID == dstID {
-			linkID = snet.Router.Interface.RemoteL1ID
-		}
+		dstMAC = routerDetermineDstMAC(snet.Router, dstIP, true)
+		linkID = snet.Router.Interface.RemoteL1ID
 
 	} else {
 		index := getHostIndexFromID(srcID)

--- a/actions.go
+++ b/actions.go
@@ -117,7 +117,7 @@ func ping(srcID string, dstIP string, count int) {
 	fmt.Printf("\nPing statistics for %s:\n", dstIP)
 	fmt.Printf("\tPackets: Sent = %d, Received = %d, Lost = %d (%d%% loss)\n\n", sendCount, recvCount, lossCount, (lossCount / sendCount * 100))
 
-	actionsync[srcID] <- 1
+	actionsync[srcID] <- lossCount
 }
 
 func pong(srcID string, frame Frame) {

--- a/actions.go
+++ b/actions.go
@@ -123,7 +123,11 @@ func ping(srcID string, dst string, count int) {
 			if pongIcmpPacket.ControlType == 0 {
 				recvCount++
 				fmt.Printf("Reply from %s: seq=%d\n", dstIP, i)
-				achievementTester(UNITED_PINGDOM)
+
+				if srcIP != dstIP {
+					achievementTester(UNITED_PINGDOM)
+				}
+
 				if dstIP == "127.0.0.1" {
 					achievementTester(SNIFF_FRAMES)
 				}

--- a/actions.go
+++ b/actions.go
@@ -21,7 +21,6 @@ func ping(srcID string, dst string, count int) {
 	debug(4, "ping", srcID, "About to ping")
 
 	identifier := idgen_int(5)
-	linkID := ""
 	srcIP := ""
 	srcMAC := ""
 	dstMAC := ""
@@ -33,20 +32,12 @@ func ping(srcID string, dst string, count int) {
 	recvCount := 0
 	lossCount := 0
 
+	// Get DNS table
 	if snet.Router.ID == srcID {
-		srcHostname = snet.Router.Hostname
-		srcIP = snet.Router.GetIP()
-		srcMAC = snet.Router.Interface.MACAddr
-		linkID = snet.Router.Interface.RemoteL1ID
 		dnsTable = snet.Router.DNSTable
 	} else {
 		for h := range snet.Hosts {
 			if snet.Hosts[h].ID == srcID {
-				srcHost = snet.Hosts[h]
-				srcHostname = snet.Hosts[h].Hostname
-				srcIP = snet.Hosts[h].GetIP()
-				srcMAC = snet.Hosts[h].Interface.MACAddr
-				linkID = snet.Hosts[h].Interface.RemoteL1ID
 				dnsTable = snet.Hosts[h].DNSTable
 			}
 		}
@@ -65,14 +56,31 @@ func ping(srcID string, dst string, count int) {
 		}
 	}
 
+	iface := Interface{}
+	if snet.Router.ID == srcID {
+		iface = snet.Router.routeToInterface(dstIP)
+		srcHostname = snet.Router.Hostname
+	} else {
+		for h := range snet.Hosts {
+			if snet.Hosts[h].ID == srcID {
+				iface = snet.Hosts[h].routeToInterface(dstIP)
+				srcHost = snet.Hosts[h]
+				srcHostname = snet.Router.Hostname
+			}
+		}
+	}
+
+	srcIP = iface.IPConfig.IPAddress.String()
+	srcMAC = iface.MACAddr
+
 	fmt.Printf("\nPinging %s from %s\n", dstIP, srcHostname)
 
 	for i := 0; i < count; i++ {
 		// Get destination MAC address
 		if snet.Router.ID == srcID {
-			dstMAC = routerDetermineDstMAC(snet.Router, dstIP, true)
+			dstMAC = routerDetermineDstMAC(snet.Router, dstIP, iface.Name, true)
 		} else {
-			dstMAC = hostDetermineDstMAC(srcHost, dstIP, true)
+			dstMAC = hostDetermineDstMAC(srcHost, dstIP, iface.Name, true)
 		}
 
 		if dstMAC == "TIMEOUT" {
@@ -96,7 +104,7 @@ func ping(srcID string, dst string, count int) {
 		frameBytes := constructFrame(srcMAC, dstMAC, "IPv4", ipv4PacketBytes)
 
 		debug(4, "ping", srcID, "Awaiting ping send")
-		sendFrame(frameBytes, linkID, srcID)
+		sendFrame(frameBytes, iface, srcID)
 		debug(2, "ping", srcID, "Ping sent")
 
 		sendCount++
@@ -140,26 +148,23 @@ func pong(srcID string, frame Frame) {
 	receivedIpv4Packet := readIPv4Packet(frame.Data)
 	receivedIcmpPacket := readICMPEchoPacket(receivedIpv4Packet.Data)
 
-	linkID := ""
 	srcIP := ""
 	srcMAC := ""
 	dstIP := readIPv4PacketHeader(receivedIpv4Packet.Header).SrcIP
 	dstMAC := ""
 
+	iface := Interface{}
 	if snet.Router.ID == srcID {
-		srcMAC = snet.Router.Interface.MACAddr
-		srcIP = snet.Router.GetIP()
-		dstMAC = routerDetermineDstMAC(snet.Router, dstIP, true)
-		linkID = snet.Router.Interface.RemoteL1ID
-
+		iface = snet.Router.routeToInterface(dstIP)
+		dstMAC = routerDetermineDstMAC(snet.Router, dstIP, iface.Name, true)
 	} else {
 		index := getHostIndexFromID(srcID)
-		srcMAC = snet.Hosts[index].Interface.MACAddr
-		srcIP = snet.Hosts[index].GetIP()
-		dstMAC = hostDetermineDstMAC(snet.Hosts[index], dstIP, true)
-
-		linkID = snet.Hosts[index].Interface.RemoteL1ID
+		iface = snet.Hosts[index].routeToInterface(dstIP)
+		dstMAC = hostDetermineDstMAC(snet.Hosts[index], dstIP, iface.Name, true)
 	}
+
+	srcIP = iface.IPConfig.IPAddress.String()
+	srcMAC = iface.MACAddr
 
 	icmpReplyPacket := ICMPEchoPacket{
 		ControlType: 0,
@@ -174,7 +179,7 @@ func pong(srcID string, frame Frame) {
 	frameBytes := constructFrame(srcMAC, dstMAC, "IPv4", ipv4PacketBytes)
 
 	debug(4, "pong", srcID, "Awaiting pong send")
-	sendFrame(frameBytes, linkID, srcID)
+	sendFrame(frameBytes, iface, srcID)
 	debug(2, "pong", srcID, "Pong sent")
 }
 
@@ -182,21 +187,20 @@ func arp_request(srcID string, targetIP string) string {
 	debug(4, "arp_request", srcID, "About to ARP request")
 
 	// Construct frame
-	linkID := ""
 	srcMAC := ""
 	srcIP := ""
 	dstMAC := "ff:ff:ff:ff:ff:ff"
 
+	iface := Interface{}
 	if srcID == snet.Router.ID {
-		srcIP = snet.Router.GetIP()
-		srcMAC = snet.Router.Interface.MACAddr
-		linkID = snet.Router.Interface.RemoteL1ID
+		iface = snet.Router.Interfaces["eth0"]
 	} else {
 		index := getHostIndexFromID(srcID)
-		srcIP = snet.Hosts[index].GetIP()
-		srcMAC = snet.Hosts[index].Interface.MACAddr
-		linkID = snet.Hosts[index].Interface.RemoteL1ID
+		iface = snet.Hosts[index].Interfaces["eth0"]
 	}
+
+	srcIP = iface.IPConfig.IPAddress.String()
+	srcMAC = iface.MACAddr
 
 	// First, check if it is trying to ARP itself.
 	if targetIP == srcIP {
@@ -219,7 +223,7 @@ func arp_request(srcID string, targetIP string) string {
 	arpRequestFrameBytes := constructFrame(srcMAC, dstMAC, "ARP", arpRequestMessageBytes)
 
 	// Send frame and wait for ARPREPLY
-	sendFrame(arpRequestFrameBytes, linkID, srcID)
+	sendFrame(arpRequestFrameBytes, iface, srcID)
 	debug(2, "arp_request", srcID, "ARPREQUEST sent")
 
 	sockets := socketMaps[srcID]
@@ -242,7 +246,6 @@ func arp_reply(id string, arpRequestFrame Frame) {
 	arpRequestMessage := readArpMessage(arpRequestFrame.Data)
 
 	// Construct frame
-	linkID := ""
 	srcID := ""
 	srcMAC := ""
 	srcIP := ""
@@ -250,18 +253,18 @@ func arp_reply(id string, arpRequestFrame Frame) {
 	dstIP := arpRequestMessage.SenderIP
 
 	// Network listener decided to reply to this request - no checking needed.
+	iface := Interface{}
 	if id == snet.Router.ID {
+		iface = snet.Router.Interfaces["eth0"]
 		srcID = snet.Router.ID
-		srcMAC = snet.Router.Interface.MACAddr
-		srcIP = snet.Router.GetIP()
-		linkID = snet.Router.Interface.RemoteL1ID
 	} else {
-		i := getHostIndexFromID(id)
-		linkID = snet.Hosts[i].Interface.RemoteL1ID
-		srcID = snet.Hosts[i].ID
-		srcMAC = snet.Hosts[i].Interface.MACAddr
-		srcIP = snet.Hosts[i].GetIP()
+		index := getHostIndexFromID(id)
+		iface = snet.Hosts[index].Interfaces["eth0"]
+		srcID = snet.Hosts[index].ID
 	}
+
+	srcIP = iface.IPConfig.IPAddress.String()
+	srcMAC = iface.MACAddr
 
 	arpReplyMessage := ArpMessage{
 		HTYPE:     1,
@@ -278,19 +281,19 @@ func arp_reply(id string, arpRequestFrame Frame) {
 	arpReplyFrameBytes := constructFrame(srcMAC, dstMAC, "ARP", arpReplyMessageBytes)
 
 	// Send frame
-	sendFrame(arpReplyFrameBytes, linkID, srcID)
+	sendFrame(arpReplyFrameBytes, iface, srcID)
 	debug(2, "arp_reply", srcID, "ARPREPLY sent")
 }
 
 func dhcp_discover(host Host) {
 	debug(4, "dhcp_discover", host.ID, "Starting DHCPDISCOVER")
 	//get info
-	srcIP := host.GetIP()
-	srcMAC := host.Interface.MACAddr
+	iface := host.Interfaces["eth0"]
+	srcIP := host.GetIP(iface.Name)
+	srcMAC := iface.MACAddr
 	srcID := host.ID
 	dstIP := "255.255.255.255"
 	dstMAC := "ff:ff:ff:ff:ff:ff"
-	linkID := host.Interface.RemoteL1ID
 
 	// Construct DHCPDISCOVER
 	options := map[byte][]byte{
@@ -321,7 +324,7 @@ func dhcp_discover(host Host) {
 
 	// Send DHCPDISCOVER, await DHCPOFFER
 	//need to give it to uplink
-	sendFrame(frameData, linkID, srcID)
+	sendFrame(frameData, iface, srcID)
 	debug(2, "dhcp_discover", host.ID, "DHCPDISCOVER sent")
 
 	sockets := socketMaps[srcID]
@@ -369,7 +372,7 @@ func dhcp_discover(host Host) {
 		dhcpRequestFrame := constructFrame(srcMAC, dstMAC, "IPv4", dhcpRequestIPv4Packet)
 
 		// Send DHCPREQUEST, await DHCPACK
-		sendFrame(dhcpRequestFrame, linkID, srcID)
+		sendFrame(dhcpRequestFrame, iface, srcID)
 		debug(2, "dhcp_discover", srcID, "DHCPREQUEST sent")
 		dhcpAckFrame := <-sockets[socketID]
 
@@ -401,15 +404,15 @@ func dhcp_offer(dhcpDiscoverFrame Frame) {
 	dhcpDiscoverUDPSegment := readUDPSegment(dhcpDiscoverIPv4Packet.Data)
 	dhcpDiscoverMessage := ReadDHCPMessage(dhcpDiscoverUDPSegment.Data)
 
-	srcIP := snet.Router.GetIP()
+	iface := snet.Router.Interfaces["eth0"]
+	srcIP := snet.Router.GetIP(iface.Name)
 	dstIP := "255.255.255.255"
-	srcMAC := snet.Router.Interface.MACAddr
+	srcMAC := iface.MACAddr
 	dstMAC := dhcpDiscoverFrame.SrcMAC // This usage of SrcMAC is according to DHCP protocol.
-	linkID := snet.Router.Interface.RemoteL1ID
 
 	// Find open address
 	addr_to_give := snet.Router.NextFreePoolAddress()
-	gateway := snet.Router.GetIP()
+	gateway := snet.Router.GetIP(iface.Name)
 	netSize, _ := strconv.Atoi(snet.Netsize)
 	subnetmask := prefixLengthToSubnetMask(netSize)
 
@@ -449,7 +452,7 @@ func dhcp_offer(dhcpDiscoverFrame Frame) {
 	dhcpOfferFrame := constructFrame(srcMAC, dstMAC, "IPv4", dhcpOfferPacket)
 
 	// Send DHCPOFFER, await DHCPREQUEST
-	sendFrame(dhcpOfferFrame, linkID, snet.Router.ID)
+	sendFrame(dhcpOfferFrame, iface, snet.Router.ID)
 	debug(2, "dhcp_offer", snet.Router.ID, "DHCPOFFER sent - "+addr_to_give.String())
 }
 
@@ -460,11 +463,11 @@ func dhcp_ack(dhcpRequestFrame Frame) {
 	dhcpRequestUDPSegment := readUDPSegment(dhcpRequestIPv4Packet.Data)
 	dhcpRequestMessage := ReadDHCPMessage(dhcpRequestUDPSegment.Data)
 
-	srcIP := snet.Router.GetIP()
+	iface := snet.Router.Interfaces["eth0"]
+	srcIP := snet.Router.GetIP(iface.Name)
 	dstIP := dhcpRequestIPv4PacketHeader.SrcIP
-	srcMAC := snet.Router.Interface.MACAddr
+	srcMAC := iface.MACAddr
 	dstMAC := dhcpRequestFrame.SrcMAC // This usage of SrcMAC is according to DHCP protocol.
-	linkID := snet.Router.Interface.RemoteL1ID
 
 	messageType := 6
 	if dhcpRequestUDPSegment.Data != nil {
@@ -479,7 +482,7 @@ func dhcp_ack(dhcpRequestFrame Frame) {
 		}
 	}
 
-	gateway := snet.Router.GetIP()
+	gateway := snet.Router.GetIP(iface.Name)
 	netSize, _ := strconv.Atoi(snet.Netsize)
 	subnetmask := prefixLengthToSubnetMask(netSize)
 
@@ -514,7 +517,7 @@ func dhcp_ack(dhcpRequestFrame Frame) {
 	dhcpAckFrame := constructFrame(srcMAC, dstMAC, "IPv4", dhcpAckIPv4Packet)
 
 	// Send DHCPACK
-	sendFrame(dhcpAckFrame, linkID, snet.Router.ID)
+	sendFrame(dhcpAckFrame, iface, snet.Router.ID)
 	debug(2, "dhcp_offer", snet.Router.ID, "DHCPACK sent - "+dhcpAckMessage.YIAddr.String())
 
 	// Setting leasee's MAC in pool (new)
@@ -530,7 +533,7 @@ func dhcp_ack(dhcpRequestFrame Frame) {
 func ipset(hostname string, ipaddr string) {
 	prefixLength, _ := strconv.Atoi(snet.Netsize)
 	subnetMask := prefixLengthToSubnetMask(prefixLength)
-	defaultGateway := snet.Router.GetIP()
+	defaultGateway := snet.Router.GetIP("eth0")
 
 	fmt.Printf("\nIP Address: %s\nSubnet mask: %s\nDefault gateway: %s\n", ipaddr, subnetMask, defaultGateway)
 	fmt.Print("\nIs this correct? [Y/n]: ")
@@ -552,9 +555,14 @@ func ipset(hostname string, ipaddr string) {
 	//update info
 	for h := range snet.Hosts {
 		if snet.Hosts[h].Hostname == hostname {
-			snet.Hosts[h].Interface.IPConfig.IPAddress = net.ParseIP(ipaddr)
-			snet.Hosts[h].Interface.IPConfig.SubnetMask = subnetMask
-			snet.Hosts[h].Interface.IPConfig.DefaultGateway = net.ParseIP(defaultGateway)
+			iface := snet.Hosts[h].Interfaces["eth0"]
+
+			iface.IPConfig.IPAddress = net.ParseIP(ipaddr)
+			iface.IPConfig.SubnetMask = subnetMask
+			iface.IPConfig.DefaultGateway = net.ParseIP(defaultGateway)
+
+			snet.Hosts[h].Interfaces["eth0"] = iface
+
 			fmt.Println("Network configuration updated")
 		}
 	}
@@ -564,9 +572,9 @@ func ipset(hostname string, ipaddr string) {
 func arpSynchronized(id string, targetIP string) {
 	dstMAC := ""
 	if snet.Router.ID == id {
-		dstMAC = routerDetermineDstMAC(snet.Router, targetIP, false)
+		dstMAC = routerDetermineDstMAC(snet.Router, targetIP, "eth0", false)
 	} else {
-		dstMAC = hostDetermineDstMAC(snet.Hosts[getHostIndexFromID(id)], targetIP, false)
+		dstMAC = hostDetermineDstMAC(snet.Hosts[getHostIndexFromID(id)], targetIP, "eth0", false)
 	}
 
 	if dstMAC != "" {
@@ -577,12 +585,12 @@ func arpSynchronized(id string, targetIP string) {
 }
 
 // A host determines the destination MAC to send to... Either by ARP, sending to GW, or reading ARP table
-func hostDetermineDstMAC(srcHost Host, dstIP string, useTable bool) string {
+func hostDetermineDstMAC(srcHost Host, dstIP string, iface string, useTable bool) string {
 	srcID := srcHost.ID
 	dstMAC := ""
 
 	// Same subnet - ARP table, or ARP request.
-	if iphelper.IPInSameSubnet(srcHost.GetIP(), dstIP, srcHost.GetMask()) {
+	if iphelper.IPInSameSubnet(srcHost.GetIP(iface), dstIP, srcHost.GetMask(iface)) {
 		debug(4, "hostDetermineDstMAC", srcID, "Sending to same subnet, about to ARP table lookup or ARP")
 
 		// Check ARP table
@@ -596,7 +604,7 @@ func hostDetermineDstMAC(srcHost Host, dstIP string, useTable bool) string {
 			} else {
 				arpEntry := ARPEntry{
 					MACAddr:   dstMAC,
-					Interface: snet.Hosts[getHostIndexFromID(srcID)].Interface.RemoteL1ID,
+					Interface: snet.Hosts[getHostIndexFromID(srcID)].Interfaces[iface].RemoteL1ID,
 				}
 				snet.Hosts[getHostIndexFromID(srcID)].ARPTable[dstIP] = arpEntry // Add to ARP table
 			}
@@ -604,7 +612,7 @@ func hostDetermineDstMAC(srcHost Host, dstIP string, useTable bool) string {
 
 	} else { // Different subnet - GW.
 		debug(4, "hostDetermineDstMAC", srcID, "Sending to different subnet, sending to GW")
-		gateway := srcHost.GetGateway()
+		gateway := srcHost.GetGateway(iface)
 
 		// Check ARP table
 		if snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway].MACAddr != "" {
@@ -617,7 +625,7 @@ func hostDetermineDstMAC(srcHost Host, dstIP string, useTable bool) string {
 			} else {
 				arpEntry := ARPEntry{
 					MACAddr:   dstMAC,
-					Interface: snet.Hosts[getHostIndexFromID(srcID)].Interface.RemoteL1ID,
+					Interface: snet.Hosts[getHostIndexFromID(srcID)].Interfaces[iface].RemoteL1ID,
 				}
 				snet.Hosts[getHostIndexFromID(srcID)].ARPTable[gateway] = arpEntry // Add to ARP table
 			}
@@ -628,13 +636,13 @@ func hostDetermineDstMAC(srcHost Host, dstIP string, useTable bool) string {
 }
 
 // A router determines the destination MAC to send to... Either by ARP, or reading ARP table
-func routerDetermineDstMAC(router Router, dstIP string, useTable bool) string {
+func routerDetermineDstMAC(router Router, dstIP string, iface string, useTable bool) string {
 	dstMAC := ""
 
 	// Same subnet - ARP table, or ARP request.
 	netsizeInt, _ := strconv.Atoi(snet.Netsize)
 	subnetMask := prefixLengthToSubnetMask(netsizeInt)
-	if iphelper.IPInSameSubnet(router.GetIP(), dstIP, subnetMask) {
+	if iphelper.IPInSameSubnet(router.GetIP(iface), dstIP, subnetMask) {
 		debug(4, "routerDetermineDstMAC", router.ID, "Sending to same subnet, about to MAC table lookup or ARP")
 
 		// Check ARP table
@@ -648,7 +656,7 @@ func routerDetermineDstMAC(router Router, dstIP string, useTable bool) string {
 			} else {
 				arpEntry := ARPEntry{
 					MACAddr:   dstMAC,
-					Interface: router.Interface.RemoteL1ID,
+					Interface: router.Interfaces[iface].RemoteL1ID,
 				}
 				snet.Router.ARPTable[dstIP] = arpEntry // Add to ARP table
 			}

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-var currentVersion = "v0.4"
+var currentVersion = "v0.4.0"
 
 func intro() {
 	fmt.Println("ltdnet " + currentVersion)

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-var currentVersion = "v0.3.2"
+var currentVersion = "v0.4"
 
 func intro() {
 	fmt.Println("ltdnet " + currentVersion)

--- a/client.go
+++ b/client.go
@@ -351,8 +351,10 @@ func main() {
 
 	go Listener()
 
-	for range snet.Hosts {
-		<-listenSync
+	for h := range snet.Hosts {
+		for range snet.Hosts[h].Interfaces {
+			<-listenSync
+		}
 	}
 	fmt.Printf("\n[Notice] Debug level is set to %d\n", getDebug())
 	fmt.Printf("[Notice] Please note that switches can't yet link to routers or other switches.\n")

--- a/client.go
+++ b/client.go
@@ -298,12 +298,12 @@ func actionsMenu() {
 			save()
 		} else {
 			fmt.Printf("Current debug level: %d\n", getDebug())
-			fmt.Println("\nAll levels:\n",
+			fmt.Println("\nAll levels (least to most verbose):\n",
 				"0 - No debugging\n",
 				"1 - Errors\n",
-				"2 - General network traffic\n",
-				"3 - All network traffic\n",
-				"4 - All sorts of garbage (development+learning)")
+				"2 - Network traffic (receive)\n",
+				"3 - Network traffic (send+receive) + Warnings\n",
+				"4 - Step-by-step device actions")
 		}
 
 	case "manual", "man":

--- a/client_test.go
+++ b/client_test.go
@@ -44,7 +44,7 @@ func TestNetworkSetup(t *testing.T) {
 	linkHostTo("h2", "r1")
 	linkHostTo("h3", "r1")
 
-	if (snet.Hosts[0].UplinkID == "") || (snet.Router.VSwitch.PortLinksRemote[1] == "") {
+	if (snet.Hosts[0].Interface.RemoteL1ID == "") || (snet.Router.VSwitch.PortLinksRemote[1] == "") {
 		t.Errorf("Host not (properly) linked")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -25,7 +25,7 @@ func TestNetworkSetup(t *testing.T) {
 	// Test 1: Add router
 	addRouter("r1", "Bobcat")
 
-	if snet.Router.GetIP() != "192.168.0.1" {
+	if snet.Router.GetIP("eth0") != "192.168.0.1" {
 		t.Errorf("Router not (properly) created")
 	}
 
@@ -44,26 +44,26 @@ func TestNetworkSetup(t *testing.T) {
 	linkHostTo("h2", "r1")
 	linkHostTo("h3", "r1")
 
-	if (snet.Hosts[0].Interface.RemoteL1ID == "") || (snet.Router.VSwitch.PortLinksRemote[1] == "") {
+	if (snet.Hosts[0].Interfaces["eth0"].RemoteL1ID == "") || (snet.Router.VSwitch.PortLinksRemote[1] == "") {
 		t.Errorf("Host not (properly) linked")
 	}
 
 	// Test 4: DHCP
 	go dhcp_discover(snet.Hosts[0])
 	<-actionsync[snet.Hosts[0].ID]
-	if snet.Hosts[0].GetIP() != "192.168.0.2" {
+	if snet.Hosts[0].GetIP("eth0") != "192.168.0.2" {
 		t.Errorf("DHCP failed for host")
 	}
 
 	go dhcp_discover(snet.Hosts[1])
 	<-actionsync[snet.Hosts[1].ID]
-	if snet.Hosts[1].GetIP() != "192.168.0.3" {
+	if snet.Hosts[1].GetIP("eth0") != "192.168.0.3" {
 		t.Errorf("DHCP failed for host")
 	}
 
 	go dhcp_discover(snet.Hosts[2])
 	<-actionsync[snet.Hosts[2].ID]
-	if snet.Hosts[2].GetIP() != "192.168.0.4" {
+	if snet.Hosts[2].GetIP("eth0") != "192.168.0.4" {
 		t.Errorf("DHCP failed for host")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -72,7 +72,16 @@ func TestNetworkSetup(t *testing.T) {
 
 	// Test 5: Pinging
 	go ping(snet.Hosts[0].ID, "192.168.0.4", 1)
-	<-actionsync[snet.Hosts[0].ID]
+	lossCount := <-actionsync[snet.Hosts[0].ID]
+	if lossCount != 0 {
+		t.Errorf("Ping from h1 to h3 failed")
+	}
+
+	go ping(snet.Hosts[0].ID, "192.168.0.2", 1)
+	lossCount = <-actionsync[snet.Hosts[0].ID]
+	if lossCount != 0 {
+		t.Errorf("Ping from h1 to h1 failed")
+	}
 
 	// Test 6: Switch linking
 	addSwitch("s1")

--- a/client_test.go
+++ b/client_test.go
@@ -25,7 +25,7 @@ func TestNetworkSetup(t *testing.T) {
 	// Test 1: Add router
 	addRouter("r1", "Bobcat")
 
-	if snet.Router.Gateway.String() != "192.168.0.1" {
+	if snet.Router.GetIP() != "192.168.0.1" {
 		t.Errorf("Router not (properly) created")
 	}
 
@@ -51,17 +51,30 @@ func TestNetworkSetup(t *testing.T) {
 	// Test 4: DHCP
 	go dhcp_discover(snet.Hosts[0])
 	<-actionsync[snet.Hosts[0].ID]
-	if snet.Hosts[0].IPAddr.String() != "192.168.0.2" {
+	if snet.Hosts[0].GetIP() != "192.168.0.2" {
 		t.Errorf("DHCP failed for host")
 	}
 
 	go dhcp_discover(snet.Hosts[1])
 	<-actionsync[snet.Hosts[1].ID]
-	if snet.Hosts[1].IPAddr.String() != "192.168.0.3" {
+	if snet.Hosts[1].GetIP() != "192.168.0.3" {
 		t.Errorf("DHCP failed for host")
 	}
 
-	// Test 5: Switching
+	go dhcp_discover(snet.Hosts[2])
+	<-actionsync[snet.Hosts[2].ID]
+	if snet.Hosts[2].GetIP() != "192.168.0.4" {
+		t.Errorf("DHCP failed for host")
+	}
+
+	// Test 5: Delete host
+	delHost("h2")
+
+	// Test 5: Pinging
+	go ping(snet.Hosts[0].ID, "192.168.0.4", 1)
+	<-actionsync[snet.Hosts[0].ID]
+
+	// Test 6: Switch linking
 	addSwitch("s1")
 	addHost("h5")
 	addHost("h6")

--- a/connhost.go
+++ b/connhost.go
@@ -162,15 +162,26 @@ func HostConn(device string, id string) {
 					displayARPTable(host.ID)
 				}
 
+			case "nslookup":
+				if len(action) > 1 {
+					address := resolveHostname(action[1], host.DNSTable)
+					fmt.Println("Name: " + action[1])
+					fmt.Println("Address: " + address + "\n")
+
+				} else {
+					fmt.Println("Usage: nslookup <hostname>")
+				}
+
 			case "exit", "quit", "q":
 				return
 
 			case "help", "?":
 				fmt.Println("",
-					"ping <dst_ip> [seconds]\tPings an IP address\n",
+					"ping\t\t\t\tPings an IP address\n",
 					"dhcp\t\t\t\tGets IP configuration via DHCP\n",
 					"ip\t\t\t\tManage IP addressing\n",
 					"arp\t\t\t\tShow and manage the ARP table\n",
+					"nslookup\t\t\tPerform a DNS lookup\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 

--- a/connhost.go
+++ b/connhost.go
@@ -57,26 +57,20 @@ func HostConn(device string, id string) {
 			case "":
 
 			case "ping":
-				if host.Interface.RemoteL1ID == "" {
-					fmt.Println("Device is not connected. Please set an uplink")
-				} else if (host.GetIP() == "0.0.0.0") || (host.GetIP() == "") {
-					fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")
-				} else {
-					if len(action) > 1 {
-						if len(action) > 2 { //if count is specified
-							count, _ := strconv.Atoi(action[2])
-							go ping(host.ID, action[1], count)
-						} else {
-							go ping(host.ID, action[1], 4)
-						}
-						<-actionsync[id]
+				if len(action) > 1 {
+					if len(action) > 2 { //if count is specified
+						count, _ := strconv.Atoi(action[2])
+						go ping(host.ID, action[1], count)
 					} else {
-						fmt.Println("Usage: ping <dst_ip> [count]")
+						go ping(host.ID, action[1], 4)
 					}
+					<-actionsync[id]
+				} else {
+					fmt.Println("Usage: ping <dst_ip> [count]")
 				}
 
 			case "dhcp":
-				if host.Interface.RemoteL1ID == "" {
+				if host.Interfaces["eth0"].RemoteL1ID == "" {
 					fmt.Println("Device is not connected. Please set an uplink")
 				} else {
 					go dhcp_discover(host)
@@ -97,14 +91,16 @@ func HostConn(device string, id string) {
 				if len(action) > 1 {
 					switch action[1] {
 					case "a", "addr", "address":
-						fmt.Println("IPv4 address: " + host.GetIP())
-						fmt.Println("Subnet mask: " + host.GetMask())
-
+						for iface := range host.Interfaces {
+							fmt.Println("Interface " + host.Interfaces[iface].Name)
+							fmt.Println("IPv4 address: " + host.GetIP(iface))
+							fmt.Println("Subnet mask: " + host.GetMask(iface))
+						}
 					case "route":
-						fmt.Println("Default gateway: " + host.GetGateway())
+						fmt.Println("Default gateway: " + host.GetGateway("eth0"))
 
 					case "set":
-						if host.Interface.RemoteL1ID == "" {
+						if host.Interfaces["eth0"].RemoteL1ID == "" {
 							fmt.Println("Device is not connected. Please set an uplink")
 						} else {
 							if len(action) > 2 {
@@ -131,17 +127,11 @@ func HostConn(device string, id string) {
 				if len(action) > 1 {
 					switch action[1] {
 					case "request":
-						if host.Interface.RemoteL1ID == "" {
-							fmt.Println("Device is not connected. Please set an uplink")
-						} else if (host.GetIP() == "0.0.0.0") || (host.GetIP() == "") {
-							fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")
+						if len(action) > 2 {
+							go arpSynchronized(id, action[2])
+							<-actionsync[id]
 						} else {
-							if len(action) > 2 {
-								go arpSynchronized(id, action[2])
-								<-actionsync[id]
-							} else {
-								fmt.Println("Usage: arp request <target_ip>")
-							}
+							fmt.Println("Usage: arp request <target_ip>")
 						}
 
 					case "clear":

--- a/connhost.go
+++ b/connhost.go
@@ -57,7 +57,7 @@ func HostConn(device string, id string) {
 			case "":
 
 			case "ping":
-				if host.UplinkID == "" {
+				if host.Interface.RemoteL1ID == "" {
 					fmt.Println("Device is not connected. Please set an uplink")
 				} else if (host.GetIP() == "0.0.0.0") || (host.GetIP() == "") {
 					fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")
@@ -76,7 +76,7 @@ func HostConn(device string, id string) {
 				}
 
 			case "dhcp":
-				if host.UplinkID == "" {
+				if host.Interface.RemoteL1ID == "" {
 					fmt.Println("Device is not connected. Please set an uplink")
 				} else {
 					go dhcp_discover(host)
@@ -104,7 +104,7 @@ func HostConn(device string, id string) {
 						fmt.Println("Default gateway: " + host.GetGateway())
 
 					case "set":
-						if host.UplinkID == "" {
+						if host.Interface.RemoteL1ID == "" {
 							fmt.Println("Device is not connected. Please set an uplink")
 						} else {
 							if len(action) > 2 {
@@ -131,7 +131,7 @@ func HostConn(device string, id string) {
 				if len(action) > 1 {
 					switch action[1] {
 					case "request":
-						if host.UplinkID == "" {
+						if host.Interface.RemoteL1ID == "" {
 							fmt.Println("Device is not connected. Please set an uplink")
 						} else if (host.GetIP() == "0.0.0.0") || (host.GetIP() == "") {
 							fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")

--- a/connhost.go
+++ b/connhost.go
@@ -92,12 +92,12 @@ func HostConn(device string, id string) {
 					switch action[1] {
 					case "a", "addr", "address":
 						for iface := range host.Interfaces {
-							fmt.Println("Interface " + host.Interfaces[iface].Name)
-							fmt.Println("IPv4 address: " + host.GetIP(iface))
-							fmt.Println("Subnet mask: " + host.GetMask(iface))
+							fmt.Printf("Interface %s\n", host.Interfaces[iface].Name)
+							fmt.Printf("\tIPv4 address: %s\n", host.GetIP(iface))
+							fmt.Printf("\tSubnet mask: %s\n\n", host.GetMask(iface))
 						}
 					case "route":
-						fmt.Println("Default gateway: " + host.GetGateway("eth0"))
+						fmt.Printf("default via %s dev %s\n", host.GetGateway("eth0"), "eth0")
 
 					case "set":
 						if host.Interfaces["eth0"].RemoteL1ID == "" {

--- a/connhost.go
+++ b/connhost.go
@@ -59,7 +59,7 @@ func HostConn(device string, id string) {
 			case "ping":
 				if host.UplinkID == "" {
 					fmt.Println("Device is not connected. Please set an uplink")
-				} else if (host.IPAddr.String() == "0.0.0.0") || (host.IPAddr == nil) {
+				} else if (host.GetIP() == "0.0.0.0") || (host.GetIP() == "") {
 					fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")
 				} else {
 					if len(action) > 1 {
@@ -97,11 +97,11 @@ func HostConn(device string, id string) {
 				if len(action) > 1 {
 					switch action[1] {
 					case "a", "addr", "address":
-						fmt.Println("IPv4 address: " + host.IPAddr.String())
-						fmt.Println("Subnet mask: " + host.SubnetMask)
+						fmt.Println("IPv4 address: " + host.GetIP())
+						fmt.Println("Subnet mask: " + host.GetMask())
 
 					case "route":
-						fmt.Println("Default gateway: " + host.DefaultGateway.String())
+						fmt.Println("Default gateway: " + host.GetGateway())
 
 					case "set":
 						if host.UplinkID == "" {
@@ -133,7 +133,7 @@ func HostConn(device string, id string) {
 					case "request":
 						if host.UplinkID == "" {
 							fmt.Println("Device is not connected. Please set an uplink")
-						} else if (host.IPAddr.String() == "0.0.0.0") || (host.IPAddr == nil) {
+						} else if (host.GetIP() == "0.0.0.0") || (host.GetIP() == "") {
 							fmt.Println("Device does not have IP configuration. Please use DHCP or statically assign an IP configuration")
 						} else {
 							if len(action) > 2 {

--- a/connrouter.go
+++ b/connrouter.go
@@ -36,7 +36,7 @@ func RouterConn(device string, id string) {
 			case "":
 
 			case "ping":
-				if (snet.Router.Gateway.String() == "0.0.0.0") || (snet.Router.Gateway == nil) {
+				if (snet.Router.GetIP() == "0.0.0.0") || (snet.Router.GetIP() == "") {
 					fmt.Println("Device does not have IP configuration. Please statically assign an IP configuration")
 				} else {
 					if len(action) > 1 {
@@ -52,7 +52,7 @@ func RouterConn(device string, id string) {
 					}
 				}
 			case "arprequest":
-				if (snet.Router.Gateway.String() == "0.0.0.0") || (snet.Router.Gateway == nil) {
+				if (snet.Router.GetIP() == "0.0.0.0") || (snet.Router.GetIP() == "") {
 					fmt.Println("Device does not have IP configuration. Please statically assign an IP configuration")
 				} else {
 					if len(action) > 1 {
@@ -80,7 +80,7 @@ func RouterConn(device string, id string) {
 					case "a", "addr", "address":
 						netsizeInt, _ := strconv.Atoi(snet.Netsize)
 						subnetMask := prefixLengthToSubnetMask(netsizeInt)
-						fmt.Println("IPv4 address: " + snet.Router.Gateway.String())
+						fmt.Println("IPv4 address: " + snet.Router.GetIP())
 						fmt.Println("Subnet mask: " + subnetMask)
 
 					case "route":
@@ -95,7 +95,7 @@ func RouterConn(device string, id string) {
 						}
 
 					case "clear":
-						ipclear(snet.Router.Gateway.String())
+						ipclear(snet.Router.GetIP())
 						save()
 
 					case "help", "?":

--- a/connrouter.go
+++ b/connrouter.go
@@ -36,7 +36,7 @@ func RouterConn(device string, id string) {
 			case "":
 
 			case "ping":
-				if (snet.Router.GetIP() == "0.0.0.0") || (snet.Router.GetIP() == "") {
+				if (snet.Router.GetIP("eth0") == "0.0.0.0") || (snet.Router.GetIP("eth0") == "") {
 					fmt.Println("Device does not have IP configuration. Please statically assign an IP configuration")
 				} else {
 					if len(action) > 1 {
@@ -51,17 +51,7 @@ func RouterConn(device string, id string) {
 						fmt.Println("Usage: ping <dst_ip> [seconds]")
 					}
 				}
-			case "arprequest":
-				if (snet.Router.GetIP() == "0.0.0.0") || (snet.Router.GetIP() == "") {
-					fmt.Println("Device does not have IP configuration. Please statically assign an IP configuration")
-				} else {
-					if len(action) > 1 {
-						go arpSynchronized(id, action[1])
-						<-actionsync[id]
-					} else {
-						fmt.Println("Usage: arp <target_ip>")
-					}
-				}
+
 			case "dhcpserver":
 				displayDHCPServer()
 
@@ -78,10 +68,11 @@ func RouterConn(device string, id string) {
 				if len(action) > 1 {
 					switch action[1] {
 					case "a", "addr", "address":
-						netsizeInt, _ := strconv.Atoi(snet.Netsize)
-						subnetMask := prefixLengthToSubnetMask(netsizeInt)
-						fmt.Println("IPv4 address: " + snet.Router.GetIP())
-						fmt.Println("Subnet mask: " + subnetMask)
+						for iface := range snet.Router.Interfaces {
+							fmt.Println("Interface " + snet.Router.Interfaces[iface].Name)
+							fmt.Println("IPv4 address: " + snet.Router.GetIP(iface))
+							fmt.Println("Subnet mask: " + snet.Router.GetMask(iface))
+						}
 
 					case "route":
 						fmt.Println("Routing not implemented yet.")
@@ -95,7 +86,7 @@ func RouterConn(device string, id string) {
 						}
 
 					case "clear":
-						ipclear(snet.Router.GetIP())
+						ipclear(snet.Router.GetIP("eth0"))
 						save()
 
 					case "help", "?":

--- a/connrouter.go
+++ b/connrouter.go
@@ -137,6 +137,16 @@ func RouterConn(device string, id string) {
 					displayARPTable(snet.Router.ID)
 				}
 
+			case "nslookup":
+				if len(action) > 1 {
+					address := resolveHostname(action[1], snet.Router.DNSTable)
+					fmt.Println("Name: " + action[1])
+					fmt.Println("Address: " + address + "\n")
+
+				} else {
+					fmt.Println("Usage: nslookup <hostname>")
+				}
+
 			case "exit", "quit", "q":
 				return
 
@@ -146,6 +156,7 @@ func RouterConn(device string, id string) {
 					"dhcpserver\t\t\tDisplays DHCP server and DHCP pool settings\n",
 					"ip\t\t\t\tManage IP addressing\n",
 					"arp\t\t\t\tShow and manage the ARP table\n",
+					"nslookup\t\t\tPerform a DNS lookup\n",
 					"exit\t\t\t\tReturns to main menu",
 				)
 			default:

--- a/connrouter.go
+++ b/connrouter.go
@@ -69,9 +69,9 @@ func RouterConn(device string, id string) {
 					switch action[1] {
 					case "a", "addr", "address":
 						for iface := range snet.Router.Interfaces {
-							fmt.Println("Interface " + snet.Router.Interfaces[iface].Name)
-							fmt.Println("IPv4 address: " + snet.Router.GetIP(iface))
-							fmt.Println("Subnet mask: " + snet.Router.GetMask(iface))
+							fmt.Printf("Interface %s\n", snet.Router.Interfaces[iface].Name)
+							fmt.Printf("\tIPv4 address: %s\n", snet.Router.GetIP(iface))
+							fmt.Printf("\tSubnet mask: %s\n\n", snet.Router.GetMask(iface))
 						}
 
 					case "route":

--- a/display.go
+++ b/display.go
@@ -74,7 +74,15 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 
 		for i := range snet.Router.VSwitch.PortLinksRemote {
 			if snet.Router.VSwitch.PortLinksRemote[i] != "" && i != 0 {
-				drawConnectedHost(snet.Router.VSwitch.PortLinksRemote[i], i, snet.Router.VSwitch)
+
+				hostID := ""
+				for h := range snet.Hosts {
+					if snet.Hosts[h].Interface.L1ID == snet.Router.VSwitch.PortLinksRemote[i] {
+						hostID = snet.Hosts[h].ID
+					}
+				}
+
+				drawConnectedHost(hostID, i, snet.Router.VSwitch)
 			}
 		}
 	}

--- a/display.go
+++ b/display.go
@@ -23,7 +23,7 @@ func drawDiagram(rootID string) {
 
 	// Unlinked hosts
 	for i := range snet.Hosts {
-		if snet.Hosts[i].UplinkID == "" {
+		if snet.Hosts[i].Interface.RemoteL1ID == "" {
 			drawHost(snet.Hosts[i].ID)
 		}
 	}
@@ -247,13 +247,13 @@ func overview() {
 		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[i].GetMask())
 		uplinkHostname := ""
 		//Router
-		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[i].UplinkID) {
+		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[i].Interface.RemoteL1ID) {
 			uplinkHostname = snet.Router.Hostname + " (" + snet.Router.VSwitch.Hostname + ")"
 		}
 
 		//Switches
 		for j := range snet.Switches {
-			if isSwitchportID(snet.Switches[j], snet.Hosts[i].UplinkID) {
+			if isSwitchportID(snet.Switches[j], snet.Hosts[i].Interface.RemoteL1ID) {
 				uplinkHostname = snet.Switches[j].Hostname
 			}
 		}
@@ -307,12 +307,12 @@ func show(hostname string) {
 		uplinkHostname := ""
 
 		//Router
-		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[id].UplinkID) {
+		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[id].Interface.RemoteL1ID) {
 			uplinkHostname = snet.Router.Hostname + " (" + snet.Router.VSwitch.Hostname + ")"
 		}
 		//Switches
 		for j := range snet.Switches {
-			if isSwitchportID(snet.Switches[j], snet.Hosts[id].UplinkID) {
+			if isSwitchportID(snet.Switches[j], snet.Hosts[id].Interface.RemoteL1ID) {
 				uplinkHostname = snet.Switches[j].Hostname
 			}
 		}

--- a/display.go
+++ b/display.go
@@ -23,7 +23,7 @@ func drawDiagram(rootID string) {
 
 	// Unlinked hosts
 	for i := range snet.Hosts {
-		if snet.Hosts[i].Interface.RemoteL1ID == "" {
+		if snet.Hosts[i].Interfaces["eth0"].RemoteL1ID == "" {
 			drawHost(snet.Hosts[i].ID)
 		}
 	}
@@ -77,7 +77,7 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 
 				hostID := ""
 				for h := range snet.Hosts {
-					if snet.Hosts[h].Interface.L1ID == snet.Router.VSwitch.PortLinksRemote[i] {
+					if snet.Hosts[h].Interfaces["eth0"].L1ID == snet.Router.VSwitch.PortLinksRemote[i] {
 						hostID = snet.Hosts[h].ID
 					}
 				}
@@ -96,7 +96,7 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 
 func drawRouter() {
 	space1 := 13 - len(snet.Router.Hostname)
-	space2 := 14 - len(snet.Router.GetIP())
+	space2 := 14 - len(snet.Router.GetIP("eth0"))
 	space3 := 16 - len(snet.Router.Model)
 
 	fmt.Println("|------------------------|")
@@ -105,7 +105,7 @@ func drawRouter() {
 	for i := 0; i < space1; i++ {
 		fmt.Printf(" ")
 	}
-	fmt.Printf("|\n| Gateway: %s", snet.Router.GetIP())
+	fmt.Printf("|\n| Gateway: %s", snet.Router.GetIP("eth0"))
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}
@@ -161,7 +161,7 @@ func drawHost(id string) {
 	h := snet.Hosts[getHostIndexFromID(id)]
 
 	space1 := 13 - len(h.Hostname)
-	space2 := 14 - len(h.GetIP())
+	space2 := 14 - len(h.GetIP("eth0"))
 	space3 := 16 - len(h.Model)
 
 	fmt.Println("")
@@ -172,7 +172,7 @@ func drawHost(id string) {
 		fmt.Printf(" ")
 	}
 	fmt.Printf("|\n")
-	fmt.Printf("| IP Addr: %s", h.GetIP())
+	fmt.Printf("| IP Addr: %s", h.GetIP("eth0"))
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}
@@ -189,7 +189,7 @@ func drawConnectedHost(id string, iter int, sw Switch) {
 	h := snet.Hosts[getHostIndexFromID(id)]
 
 	space1 := 13 - len(h.Hostname)
-	space2 := 14 - len(h.GetIP())
+	space2 := 14 - len(h.GetIP("eth0"))
 	space3 := 16 - len(h.Model)
 
 	fmt.Println("            ||")
@@ -200,7 +200,7 @@ func drawConnectedHost(id string, iter int, sw Switch) {
 		fmt.Printf(" ")
 	}
 	fmt.Printf("|\n")
-	fmt.Printf("            ||------| IP Addr: %s", h.GetIP())
+	fmt.Printf("            ||------| IP Addr: %s", h.GetIP("eth0"))
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}
@@ -249,19 +249,19 @@ func overview() {
 		fmt.Printf("\nHost %v\n", snet.Hosts[i].Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Hosts[i].ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Hosts[i].Model)
-		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[i].Interface.MACAddr)
-		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[i].GetIP())
-		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[i].GetGateway())
-		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[i].GetMask())
+		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[i].Interfaces["eth0"].MACAddr)
+		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[i].GetIP("eth0"))
+		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[i].GetGateway("eth0"))
+		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[i].GetMask("eth0"))
 		uplinkHostname := ""
 		//Router
-		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[i].Interface.RemoteL1ID) {
+		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[i].Interfaces["eth0"].RemoteL1ID) {
 			uplinkHostname = snet.Router.Hostname + " (" + snet.Router.VSwitch.Hostname + ")"
 		}
 
 		//Switches
 		for j := range snet.Switches {
-			if isSwitchportID(snet.Switches[j], snet.Hosts[i].Interface.RemoteL1ID) {
+			if isSwitchportID(snet.Switches[j], snet.Hosts[i].Interfaces["eth0"].RemoteL1ID) {
 				uplinkHostname = snet.Switches[j].Hostname
 			}
 		}
@@ -308,19 +308,19 @@ func show(hostname string) {
 		fmt.Printf("\nHost %v\n", snet.Hosts[id].Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Hosts[id].ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Hosts[id].Model)
-		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[id].Interface.MACAddr)
-		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[id].GetIP())
-		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[id].GetGateway())
-		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[id].GetMask())
+		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[id].Interfaces["eth0"].MACAddr)
+		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[id].GetIP("eth0"))
+		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[id].GetGateway("eth0"))
+		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[id].GetMask("eth0"))
 		uplinkHostname := ""
 
 		//Router
-		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[id].Interface.RemoteL1ID) {
+		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[id].Interfaces["eth0"].RemoteL1ID) {
 			uplinkHostname = snet.Router.Hostname + " (" + snet.Router.VSwitch.Hostname + ")"
 		}
 		//Switches
 		for j := range snet.Switches {
-			if isSwitchportID(snet.Switches[j], snet.Hosts[id].Interface.RemoteL1ID) {
+			if isSwitchportID(snet.Switches[j], snet.Hosts[id].Interfaces["eth0"].RemoteL1ID) {
 				uplinkHostname = snet.Switches[j].Hostname
 			}
 		}
@@ -338,8 +338,8 @@ func show(hostname string) {
 		fmt.Printf("\nRouter %s\n", snet.Router.Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Router.ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Router.Model)
-		fmt.Printf("\tMAC:\t\t%s\n", snet.Router.Interface.MACAddr)
-		fmt.Printf("\tGateway:\t%s\n", snet.Router.GetIP())
+		fmt.Printf("\tMAC:\t\t%s\n", snet.Router.Interfaces["eth0"].MACAddr)
+		fmt.Printf("\tGateway:\t%s\n", snet.Router.GetIP("eth0"))
 		fmt.Printf("\tDHCP pool:\t%d addresses\n", len(snet.Router.GetDHCPPoolAddresses()))
 		fmt.Printf("\tVSwitch ID: \t%s\n", snet.Router.VSwitch.ID)
 	}

--- a/display.go
+++ b/display.go
@@ -88,7 +88,7 @@ func drawDiagramAction(rootID string, rootType string) { // TODO make recursive 
 
 func drawRouter() {
 	space1 := 13 - len(snet.Router.Hostname)
-	space2 := 14 - len(snet.Router.Gateway.String())
+	space2 := 14 - len(snet.Router.GetIP())
 	space3 := 16 - len(snet.Router.Model)
 
 	fmt.Println("|------------------------|")
@@ -97,7 +97,7 @@ func drawRouter() {
 	for i := 0; i < space1; i++ {
 		fmt.Printf(" ")
 	}
-	fmt.Printf("|\n| Gateway: %s", snet.Router.Gateway.String())
+	fmt.Printf("|\n| Gateway: %s", snet.Router.GetIP())
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}
@@ -153,7 +153,7 @@ func drawHost(id string) {
 	h := snet.Hosts[getHostIndexFromID(id)]
 
 	space1 := 13 - len(h.Hostname)
-	space2 := 14 - len(h.IPAddr.String())
+	space2 := 14 - len(h.GetIP())
 	space3 := 16 - len(h.Model)
 
 	fmt.Println("")
@@ -164,7 +164,7 @@ func drawHost(id string) {
 		fmt.Printf(" ")
 	}
 	fmt.Printf("|\n")
-	fmt.Printf("| IP Addr: %s", h.IPAddr)
+	fmt.Printf("| IP Addr: %s", h.GetIP())
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}
@@ -181,7 +181,7 @@ func drawConnectedHost(id string, iter int, sw Switch) {
 	h := snet.Hosts[getHostIndexFromID(id)]
 
 	space1 := 13 - len(h.Hostname)
-	space2 := 14 - len(h.IPAddr.String())
+	space2 := 14 - len(h.GetIP())
 	space3 := 16 - len(h.Model)
 
 	fmt.Println("            ||")
@@ -192,7 +192,7 @@ func drawConnectedHost(id string, iter int, sw Switch) {
 		fmt.Printf(" ")
 	}
 	fmt.Printf("|\n")
-	fmt.Printf("            ||------| IP Addr: %s", h.IPAddr)
+	fmt.Printf("            ||------| IP Addr: %s", h.GetIP())
 	for i := 0; i < space2; i++ {
 		fmt.Printf(" ")
 	}
@@ -232,7 +232,6 @@ func overview() {
 		fmt.Printf("\nSwitch %v\n", snet.Switches[i].Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Switches[i].ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Switches[i].Model)
-		fmt.Printf("\tMgmt IP:\t%s\n", snet.Switches[i].MgmtIP)
 		switchCount = i + 1
 	}
 
@@ -242,10 +241,10 @@ func overview() {
 		fmt.Printf("\nHost %v\n", snet.Hosts[i].Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Hosts[i].ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Hosts[i].Model)
-		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[i].MACAddr)
-		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[i].IPAddr.String())
-		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[i].DefaultGateway.String())
-		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[i].SubnetMask)
+		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[i].Interface.MACAddr)
+		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[i].GetIP())
+		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[i].GetGateway())
+		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[i].GetMask())
 		uplinkHostname := ""
 		//Router
 		if isSwitchportID(snet.Router.VSwitch, snet.Hosts[i].UplinkID) {
@@ -301,10 +300,10 @@ func show(hostname string) {
 		fmt.Printf("\nHost %v\n", snet.Hosts[id].Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Hosts[id].ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Hosts[id].Model)
-		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[id].MACAddr)
-		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[id].IPAddr.String())
-		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[id].DefaultGateway.String())
-		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[id].SubnetMask)
+		fmt.Printf("\tMAC:\t\t%s\n", snet.Hosts[id].Interface.MACAddr)
+		fmt.Printf("\tIP Address:\t%s\n", snet.Hosts[id].GetIP())
+		fmt.Printf("\tDef. Gateway:\t%s\n", snet.Hosts[id].GetGateway())
+		fmt.Printf("\tSubnet Mask:\t%s\n", snet.Hosts[id].GetMask())
 		uplinkHostname := ""
 
 		//Router
@@ -323,18 +322,16 @@ func show(hostname string) {
 		fmt.Printf("\nSwitch %s\n", snet.Switches[id].Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Switches[id].ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Switches[id].Model)
-		fmt.Printf("\tMgmt IP:\t%s\n\n", snet.Switches[id].MgmtIP)
 	} else if device_type == "vswitch" {
 		fmt.Printf("\nSwitch %s\n", snet.Router.VSwitch.Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Router.VSwitch.ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Router.VSwitch.Model)
-		fmt.Printf("\tMgmt IP:\t%s\n\n", snet.Router.VSwitch.MgmtIP)
 	} else if device_type == "router" {
 		fmt.Printf("\nRouter %s\n", snet.Router.Hostname)
 		fmt.Printf("\tID:\t\t%s\n", snet.Router.ID)
 		fmt.Printf("\tModel:\t\t%s\n", snet.Router.Model)
-		fmt.Printf("\tMAC:\t\t%s\n", snet.Router.MACAddr)
-		fmt.Printf("\tGateway:\t%s\n", snet.Router.Gateway.String())
+		fmt.Printf("\tMAC:\t\t%s\n", snet.Router.Interface.MACAddr)
+		fmt.Printf("\tGateway:\t%s\n", snet.Router.GetIP())
 		fmt.Printf("\tDHCP pool:\t%d addresses\n", len(snet.Router.GetDHCPPoolAddresses()))
 		fmt.Printf("\tVSwitch ID: \t%s\n", snet.Router.VSwitch.ID)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -78,7 +78,7 @@ func getHostIndexFromID(id string) int {
 
 func getHostIndexFromLinkID(id string) int {
 	for h := range snet.Hosts {
-		if snet.Hosts[h].Interface.RemoteL1ID == id {
+		if snet.Hosts[h].Interfaces["eth0"].RemoteL1ID == id {
 			return h
 		}
 	}
@@ -130,13 +130,13 @@ func getSwitchIDFromLink(link string) string {
 
 func getIDfromMAC(mac string) string {
 	//Router
-	if mac == snet.Router.Interface.MACAddr {
+	if mac == snet.Router.Interfaces["eth0"].MACAddr {
 		return snet.Router.ID
 	}
 
 	//Hosts
 	for h := range snet.Hosts {
-		if snet.Hosts[h].Interface.MACAddr == mac {
+		if snet.Hosts[h].Interfaces["eth0"].MACAddr == mac {
 			return snet.Hosts[h].ID
 		}
 	}
@@ -147,9 +147,14 @@ func getIDfromMAC(mac string) string {
 func dynamic_assign(id string, ipaddr net.IP, defaultgateway net.IP, subnetMask string) {
 	for h := range snet.Hosts {
 		if snet.Hosts[h].ID == id {
-			snet.Hosts[h].Interface.IPConfig.IPAddress = ipaddr
-			snet.Hosts[h].Interface.IPConfig.SubnetMask = subnetMask
-			snet.Hosts[h].Interface.IPConfig.DefaultGateway = defaultgateway
+			iface := snet.Hosts[h].Interfaces["eth0"]
+
+			iface.IPConfig.IPAddress = ipaddr
+			iface.IPConfig.SubnetMask = subnetMask
+			iface.IPConfig.DefaultGateway = defaultgateway
+
+			snet.Hosts[h].Interfaces["eth0"] = iface
+
 			fmt.Println("Network configuration updated")
 		}
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -130,13 +130,13 @@ func getSwitchIDFromLink(link string) string {
 
 func getIDfromMAC(mac string) string {
 	//Router
-	if mac == snet.Router.MACAddr {
+	if mac == snet.Router.Interface.MACAddr {
 		return snet.Router.ID
 	}
 
 	//Hosts
 	for h := range snet.Hosts {
-		if snet.Hosts[h].MACAddr == mac {
+		if snet.Hosts[h].Interface.MACAddr == mac {
 			return snet.Hosts[h].ID
 		}
 	}
@@ -144,12 +144,12 @@ func getIDfromMAC(mac string) string {
 	return ""
 }
 
-func dynamic_assign(id string, ipaddr net.IP, defaultgateway net.IP, subnetmask string) {
+func dynamic_assign(id string, ipaddr net.IP, defaultgateway net.IP, subnetMask string) {
 	for h := range snet.Hosts {
 		if snet.Hosts[h].ID == id {
-			snet.Hosts[h].IPAddr = ipaddr
-			snet.Hosts[h].SubnetMask = subnetmask
-			snet.Hosts[h].DefaultGateway = defaultgateway
+			snet.Hosts[h].Interface.IPConfig.IPAddress = ipaddr
+			snet.Hosts[h].Interface.IPConfig.SubnetMask = subnetMask
+			snet.Hosts[h].Interface.IPConfig.DefaultGateway = defaultgateway
 			fmt.Println("Network configuration updated")
 		}
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -78,7 +78,7 @@ func getHostIndexFromID(id string) int {
 
 func getHostIndexFromLinkID(id string) int {
 	for h := range snet.Hosts {
-		if snet.Hosts[h].UplinkID == id {
+		if snet.Hosts[h].Interface.RemoteL1ID == id {
 			return h
 		}
 	}

--- a/host.go
+++ b/host.go
@@ -96,11 +96,6 @@ func addHost(hostHostname string) {
 		IPConfig: eth0IPConfig,
 	}
 
-	h.ARPTable["127.0.0.1"] = ARPEntry{
-		MACAddr:   h.Interfaces["lo"].MACAddr,
-		Interface: "lo",
-	}
-
 	// DNS table
 	h.DNSTable = make(map[string]DNSEntry)
 
@@ -261,6 +256,6 @@ func (host Host) routeToInterface(dstIP string) Interface {
 	}
 
 	// Default gateway
-	debug(4, host.Hostname, "routeToInterface", "Route not found. Sending to default gateway")
+	debug(4, "routeToInterface", host.Hostname, "Route not found. Sending to default gateway")
 	return host.Interfaces["eth0"]
 }

--- a/host.go
+++ b/host.go
@@ -53,12 +53,7 @@ func addHost(hostHostname string) {
 		return
 	}
 
-	h := Host{
-		Interfaces: map[string]Interface{
-			"eth0": Interface{},
-			"lo":   Interface{},
-		},
-	}
+	h := Host{}
 	if hostModel == "PROBOX" {
 		h = NewProbox(h)
 	} else {
@@ -99,6 +94,11 @@ func addHost(hostHostname string) {
 		L1ID:     idgen(8),
 		MACAddr:  macgen(),
 		IPConfig: eth0IPConfig,
+	}
+
+	h.ARPTable["127.0.0.1"] = ARPEntry{
+		MACAddr:   h.Interfaces["lo"].MACAddr,
+		Interface: "lo",
 	}
 
 	// DNS table
@@ -261,5 +261,6 @@ func (host Host) routeToInterface(dstIP string) Interface {
 	}
 
 	// Default gateway
+	debug(4, host.Hostname, "routeToInterface", "Route not found. Sending to default gateway")
 	return host.Interfaces["eth0"]
 }

--- a/host.go
+++ b/host.go
@@ -17,6 +17,7 @@ type Host struct {
 	Model     string              `json:"model"`
 	Hostname  string              `json:"hostname"`
 	ARPTable  map[string]ARPEntry `json:"arptable"`
+	DNSTable  map[string]DNSEntry `json:"dnstable"`
 	Interface Interface           `json:"interface"`
 }
 
@@ -25,6 +26,13 @@ type ARPEntry struct {
 	ExpireTime time.Time `json:"expireTime"`
 	Interface  string    `json:"interface"`
 	State      string    `json:"state"`
+}
+
+type DNSEntry struct {
+	IPAddress  string    // Resolved IP address
+	TTL        int       // Time-to-live in seconds, for cache expiration
+	RecordType string    // Type of DNS record ("A", "AAAA")
+	Timestamp  time.Time // Time the entry was created, for tracking TTL expiration
 }
 
 // Populate fields specific to the Probox 1
@@ -55,6 +63,22 @@ func addHost(hostHostname string) {
 	h.ID = idgen(8)
 	h.Hostname = hostHostname
 	h.ARPTable = make(map[string]ARPEntry)
+
+	// DNS table
+	h.DNSTable = make(map[string]DNSEntry)
+
+	h.DNSTable[h.Hostname] = DNSEntry{
+		IPAddress:  "127.0.0.1",
+		TTL:        -1,
+		RecordType: "A",
+		Timestamp:  time.Time{},
+	}
+	h.DNSTable["localhost"] = DNSEntry{
+		IPAddress:  "127.0.0.1",
+		TTL:        -1,
+		RecordType: "A",
+		Timestamp:  time.Time{},
+	}
 
 	ipConfig := IPConfig{
 		IPAddress:      nil,

--- a/interface.go
+++ b/interface.go
@@ -9,6 +9,7 @@ package main
 import "net"
 
 type Interface struct {
+	Name       string   `json:"name"`
 	L1ID       string   `json:"id"`             // L1ID establishes one end of a Layer-1 connection
 	RemoteL1ID string   `json:"remote_link_id"` // Remote L1ID this interface is connected to
 	MACAddr    string   `json:"macaddr"`        // MAC Address
@@ -23,22 +24,22 @@ type IPConfig struct {
 	ConfigType     string `json:"configtype"` // Static or DHCP
 }
 
-func (h *Host) GetIP() string {
-	return h.Interface.IPConfig.IPAddress.String()
+func (h *Host) GetIP(interfaceName string) string {
+	return h.Interfaces[interfaceName].IPConfig.IPAddress.String()
 }
 
-func (h *Host) GetMask() string {
-	return h.Interface.IPConfig.SubnetMask
+func (h *Host) GetMask(interfaceName string) string {
+	return h.Interfaces[interfaceName].IPConfig.SubnetMask
 }
 
-func (h *Host) GetGateway() string {
-	return h.Interface.IPConfig.DefaultGateway.String()
+func (h *Host) GetGateway(interfaceName string) string {
+	return h.Interfaces[interfaceName].IPConfig.DefaultGateway.String()
 }
 
-func (r *Router) GetIP() string {
-	return r.Interface.IPConfig.IPAddress.String()
+func (r *Router) GetIP(interfaceName string) string {
+	return r.Interfaces[interfaceName].IPConfig.IPAddress.String()
 }
 
-func (r *Router) GetMask() string {
-	return r.Interface.IPConfig.SubnetMask
+func (r *Router) GetMask(interfaceName string) string {
+	return r.Interfaces[interfaceName].IPConfig.SubnetMask
 }

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,44 @@
+/*
+File:		interface.go
+Author: 	https://github.com/vincebel7
+Purpose: 	Network interface
+*/
+
+package main
+
+import "net"
+
+type Interface struct {
+	L1ID       string   `json:"id"`             // L1ID establishes one end of a Layer-1 connection
+	RemoteL1ID string   `json:"remote_link_id"` // Remote L1ID this interface is connected to
+	MACAddr    string   `json:"macaddr"`        // MAC Address
+	IPConfig   IPConfig `json:"ipconfig"`
+}
+
+type IPConfig struct {
+	IPAddress      net.IP `json:"ip"`
+	SubnetMask     string `json:"subnetmask"`
+	DefaultGateway net.IP `json:"gateway"`
+	DNSServer      net.IP `json:"dns"`
+	ConfigType     string `json:"configtype"` // Static or DHCP
+}
+
+func (h *Host) GetIP() string {
+	return h.Interface.IPConfig.IPAddress.String()
+}
+
+func (h *Host) GetMask() string {
+	return h.Interface.IPConfig.SubnetMask
+}
+
+func (h *Host) GetGateway() string {
+	return h.Interface.IPConfig.DefaultGateway.String()
+}
+
+func (r *Router) GetIP() string {
+	return r.Interface.IPConfig.IPAddress.String()
+}
+
+func (r *Router) GetMask() string {
+	return r.Interface.IPConfig.SubnetMask
+}

--- a/listener.go
+++ b/listener.go
@@ -105,9 +105,9 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 			debug(3, "actionHandler", id, "ARPREPLY received")
 
 			amTarget := false
-			if (snet.Router.ID == id) && (arpMessage.TargetIP == snet.Router.Gateway.String()) {
+			if (snet.Router.ID == id) && (arpMessage.TargetIP == snet.Router.GetIP()) {
 				amTarget = true
-			} else if (snet.Router.ID != id) && (arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
+			} else if (snet.Router.ID != id) && (arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].GetIP()) {
 				amTarget = true
 			}
 			if amTarget {
@@ -121,9 +121,9 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 
 			// Check if target device at network-level
 			amTarget := false
-			if (snet.Router.ID == id) && (arpMessage.TargetIP == snet.Router.Gateway.String()) {
+			if (snet.Router.ID == id) && (arpMessage.TargetIP == snet.Router.GetIP()) {
 				amTarget = true
-			} else if (snet.Router.ID != id) && (arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
+			} else if (snet.Router.ID != id) && (arpMessage.TargetIP == snet.Hosts[getHostIndexFromID(id)].GetIP()) {
 				amTarget = true
 			}
 
@@ -146,9 +146,9 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 
 				// Check if target device at network-level
 				amTarget := false
-				if (snet.Router.ID == id) && (packetHeader.DstIP == snet.Router.Gateway.String()) {
+				if (snet.Router.ID == id) && (packetHeader.DstIP == snet.Router.GetIP()) {
 					amTarget = true
-				} else if (snet.Router.ID != id) && (packetHeader.DstIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
+				} else if (snet.Router.ID != id) && (packetHeader.DstIP == snet.Hosts[getHostIndexFromID(id)].GetIP()) {
 					amTarget = true
 				}
 
@@ -161,9 +161,9 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 
 				// Check if target device at network-level
 				amTarget := false
-				if (snet.Router.ID == id) && (packetHeader.DstIP == snet.Router.Gateway.String()) {
+				if (snet.Router.ID == id) && (packetHeader.DstIP == snet.Router.GetIP()) {
 					amTarget = true
-				} else if (snet.Router.ID != id) && (packetHeader.DstIP == snet.Hosts[getHostIndexFromID(id)].IPAddr.String()) {
+				} else if (snet.Router.ID != id) && (packetHeader.DstIP == snet.Hosts[getHostIndexFromID(id)].GetIP()) {
 					amTarget = true
 				}
 
@@ -209,7 +209,7 @@ func actionHandler(rawFrame json.RawMessage, id string) {
 			case 68: // DHCP: Client-bound
 				dhcpMessage := ReadDHCPMessage(json.RawMessage(udpSegment.Data))
 
-				if dhcpMessage.CHAddr == snet.Hosts[getHostIndexFromID(id)].MACAddr { // I am target
+				if dhcpMessage.CHAddr == snet.Hosts[getHostIndexFromID(id)].Interface.MACAddr { // I am target
 					// 53 is DHCP message type
 					if option53, ok := dhcpMessage.Options[53]; ok && len(option53) > 0 {
 						switch int(option53[0]) {

--- a/listener.go
+++ b/listener.go
@@ -43,13 +43,13 @@ func Listener() {
 	}
 
 	for i := range snet.Hosts {
-		go listenHostChannel(snet.Hosts[i].ID)
+		go listenHostChannel(snet.Hosts[i])
 	}
 
 }
 
 func generateHostChannels(i int) {
-	channels[snet.Hosts[i].ID] = make(chan json.RawMessage)
+	channels[snet.Hosts[i].Interface.L1ID] = make(chan json.RawMessage)
 	socketMaps[snet.Hosts[i].ID] = make(map[string]chan Frame)
 	actionsync[snet.Hosts[i].ID] = make(chan int)
 }
@@ -64,7 +64,7 @@ func generateSwitchChannels(i int) {
 
 func generateRouterChannels() {
 	if snet.Router.Hostname != "" {
-		channels[snet.Router.ID] = make(chan json.RawMessage)
+		channels[snet.Router.Interface.L1ID] = make(chan json.RawMessage)
 		socketMaps[snet.Router.ID] = make(map[string]chan Frame)
 
 		for i := 0; i < getActivePorts(snet.Router.VSwitch); i++ {
@@ -75,19 +75,19 @@ func generateRouterChannels() {
 	}
 }
 
-func listenHostChannel(id string) {
-	listenSync <- id //synchronizing with client.go
+func listenHostChannel(host Host) {
+	listenSync <- host.ID //synchronizing with client.go
 
 	for {
-		rawFrame := <-channels[id]
-		debug(4, "listenHostChannel", id, "Received unicast frame")
-		go actionHandler(rawFrame, id)
+		rawFrame := <-channels[host.Interface.L1ID]
+		debug(4, "listenHostChannel", host.Hostname, "Received unicast frame")
+		go actionHandler(rawFrame, host.ID)
 	}
 }
 
 func listenRouterChannel() {
 	for {
-		rawFrame := <-channels[snet.Router.ID]
+		rawFrame := <-channels[snet.Router.Interface.L1ID]
 		debug(4, "listenRouterChannel", snet.Router.ID, "Received unicast frame")
 		go actionHandler(rawFrame, snet.Router.ID)
 	}

--- a/listener.go
+++ b/listener.go
@@ -241,8 +241,8 @@ func listenSwitchportChannel(switchID string, switchportID string) {
 	for {
 		rawFrame := <-channels[switchportID]
 		debug(4, "listenSwitchportChannel", switchportID, "(Switch) Received frame from port "+switchportID)
-
 		port := getSwitchportIDFromLink(switchportID)
+
 		checkMACTable(readFrame(rawFrame).SrcMAC, switchportID, port)
 
 		go switchportActionHandler(rawFrame, switchID, switchportID)

--- a/router.go
+++ b/router.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/vincebel7/ltdnet/iphelper"
 )
@@ -23,6 +24,7 @@ type Router struct {
 	VSwitch   Switch              `json:"vswitchid"` // Virtual built-in switch to router
 	DHCPPool  DHCPPool            `json:"dhcp_pool"` // Instance of DHCPPool
 	ARPTable  map[string]ARPEntry `json:"arptable"`
+	DNSTable  map[string]DNSEntry `json:"dnstable"`
 	Interface Interface           `json:"interface"`
 }
 
@@ -102,6 +104,23 @@ func addRouter(routerHostname string, routerModel string) {
 	r.ARPTable = make(map[string]ARPEntry)
 
 	netsizeInt, _ := strconv.Atoi(snet.Netsize)
+
+	// DNS table
+	r.DNSTable = make(map[string]DNSEntry)
+
+	r.DNSTable[r.Hostname] = DNSEntry{
+		IPAddress:  "127.0.0.1",
+		TTL:        -1,
+		RecordType: "A",
+		Timestamp:  time.Time{},
+	}
+	r.DNSTable["localhost"] = DNSEntry{
+		IPAddress:  "127.0.0.1",
+		TTL:        -1,
+		RecordType: "A",
+		Timestamp:  time.Time{},
+	}
+
 	ipConfig := IPConfig{
 		IPAddress:  gateway,
 		SubnetMask: prefixLengthToSubnetMask(netsizeInt),

--- a/router.go
+++ b/router.go
@@ -23,7 +23,6 @@ type Router struct {
 	VSwitch   Switch              `json:"vswitchid"` // Virtual built-in switch to router
 	DHCPPool  DHCPPool            `json:"dhcp_pool"` // Instance of DHCPPool
 	ARPTable  map[string]ARPEntry `json:"arptable"`
-	LANLinkID string              `json:"lanlinkid"` // link ID for its LAN connection
 	Interface Interface           `json:"interface"`
 }
 
@@ -127,9 +126,9 @@ func addRouter(routerHostname string, routerModel string) {
 
 	snet.Router = r
 
-	assignSwitchport(snet.Router.VSwitch, snet.Router.ID)
+	assignSwitchport(snet.Router.VSwitch, snet.Router.Interface.L1ID)
 
-	snet.Router.LANLinkID = snet.Router.VSwitch.PortLinksLocal[0]
+	snet.Router.Interface.RemoteL1ID = snet.Router.VSwitch.PortLinksLocal[0]
 
 	generateRouterChannels()
 	go listenRouterChannel()

--- a/router.go
+++ b/router.go
@@ -73,12 +73,7 @@ func addRouter(routerHostname string, routerModel string) {
 		return
 	}
 
-	r := Router{
-		Interfaces: map[string]Interface{
-			"eth0": Interface{},
-			"lo":   Interface{},
-		},
-	}
+	r := Router{}
 
 	dhcpPoolSize := 0
 

--- a/router.go
+++ b/router.go
@@ -133,11 +133,6 @@ func addRouter(routerHostname string, routerModel string) {
 		IPConfig: eth0IPConfig,
 	}
 
-	r.ARPTable["127.0.0.1"] = ARPEntry{
-		MACAddr:   r.Interfaces["lo"].MACAddr,
-		Interface: "lo",
-	}
-
 	// DNS table
 	r.DNSTable = make(map[string]DNSEntry)
 

--- a/router.go
+++ b/router.go
@@ -133,6 +133,11 @@ func addRouter(routerHostname string, routerModel string) {
 		IPConfig: eth0IPConfig,
 	}
 
+	r.ARPTable["127.0.0.1"] = ARPEntry{
+		MACAddr:   r.Interfaces["lo"].MACAddr,
+		Interface: "lo",
+	}
+
 	// DNS table
 	r.DNSTable = make(map[string]DNSEntry)
 

--- a/sender.go
+++ b/sender.go
@@ -31,18 +31,17 @@ func sendFrame(frameBytes json.RawMessage, linkID string, srcID string) {
 }
 
 func isToSelf(frame Frame) bool {
-	// L2
+	// L2 (Reminder: ARPREQUEST is broadcast, not mirrored)
 	if frame.SrcMAC == frame.DstMAC {
 		return true
 	}
 
 	// L3 (optional)
-	/**
-	packet := readIPv4Packet(frame.Data)
+	if frame.EtherType == "0x0800" { // IPv4
+		packet := readIPv4Packet(frame.Data)
+		packetHeader := readIPv4PacketHeader(packet.Header)
+		return packetHeader.SrcIP == packetHeader.DstIP
+	}
 
-	if frame.Data()
-	packetHeader := readIPv4PacketHeader(packet.Header)
-	return packetHeader.SrcIP == packetHeader.DstIP
-	**/
 	return false
 }

--- a/sender.go
+++ b/sender.go
@@ -1,0 +1,48 @@
+/*
+File:		sender.go
+Author: 	https://github.com/vincebel7
+Purpose:	Handles the sending of frames
+*/
+
+package main
+
+import (
+	"encoding/json"
+)
+
+func sendFrame(frameBytes json.RawMessage, linkID string, srcID string) {
+	if isToSelf(readFrame(frameBytes)) {
+		debug(4, "sendFrame", srcID, "Frame destination is to itself. Mirroring back across the interface.")
+
+		mirrorLinkID := ""
+
+		if srcID == snet.Router.ID {
+			mirrorLinkID = snet.Router.Interface.L1ID
+		} else {
+			index := getHostIndexFromID(srcID)
+			mirrorLinkID = snet.Hosts[index].Interface.L1ID
+		}
+
+		channels[mirrorLinkID] <- frameBytes
+
+	} else {
+		channels[linkID] <- frameBytes
+	}
+}
+
+func isToSelf(frame Frame) bool {
+	// L2
+	if frame.SrcMAC == frame.DstMAC {
+		return true
+	}
+
+	// L3 (optional)
+	/**
+	packet := readIPv4Packet(frame.Data)
+
+	if frame.Data()
+	packetHeader := readIPv4PacketHeader(packet.Header)
+	return packetHeader.SrcIP == packetHeader.DstIP
+	**/
+	return false
+}

--- a/sender.go
+++ b/sender.go
@@ -10,23 +10,15 @@ import (
 	"encoding/json"
 )
 
-func sendFrame(frameBytes json.RawMessage, linkID string, srcID string) {
+func sendFrame(frameBytes json.RawMessage, iface Interface, srcID string) {
 	if isToSelf(readFrame(frameBytes)) {
 		debug(4, "sendFrame", srcID, "Frame destination is to itself. Mirroring back across the interface.")
 
-		mirrorLinkID := ""
-
-		if srcID == snet.Router.ID {
-			mirrorLinkID = snet.Router.Interface.L1ID
-		} else {
-			index := getHostIndexFromID(srcID)
-			mirrorLinkID = snet.Hosts[index].Interface.L1ID
-		}
-
+		mirrorLinkID := iface.L1ID
 		channels[mirrorLinkID] <- frameBytes
 
 	} else {
-		channels[linkID] <- frameBytes
+		channels[iface.RemoteL1ID] <- frameBytes
 	}
 }
 

--- a/switch.go
+++ b/switch.go
@@ -114,8 +114,10 @@ func delSwitch(hostname string) {
 				if snet.Switches[i].PortLinksRemote[j] != "" {
 					// Unlink if host
 					for h := range snet.Hosts {
-						if snet.Hosts[h].Interface.RemoteL1ID == snet.Switches[i].PortLinksLocal[j] {
-							snet.Hosts[h].Interface.RemoteL1ID = ""
+						if snet.Hosts[h].Interfaces["eth0"].RemoteL1ID == snet.Switches[i].PortLinksLocal[j] {
+							iface := snet.Hosts[h].Interfaces["eth0"]
+							iface.RemoteL1ID = ""
+							snet.Hosts[h].Interfaces["eth0"] = iface
 						}
 					}
 
@@ -220,7 +222,7 @@ func lookupMACTable(dstMAC string, switchportID string) int { // For looking up 
 }
 
 func checkMACTable(macaddr string, id string, port int) { // For updating MAC table on incoming frames
-	result := 0
+	result := -1
 	table := make(map[string]MACEntry)
 	if isSwitchportID(snet.Router.VSwitch, id) {
 		table = snet.Router.VSwitch.MACTable
@@ -244,7 +246,7 @@ func checkMACTable(macaddr string, id string, port int) { // For updating MAC ta
 		}
 	}
 
-	if result == 0 {
+	if result == -1 {
 		msg := "Source address " + macaddr + " not found in MAC table. Adding"
 		debug(3, "learnMACTable", id, msg)
 		addMACEntry(macaddr, id, port)
@@ -325,7 +327,7 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 		debug(4, "switchforward", switchID, "L2 Broadcast. Flooding frame on all ports")
 	} else if outboundPort == -1 { // No matching port for this MAC address was found in the MAC address table
 		floodFrame = true
-		debug(4, "switchforward", switchID, "Destination address not found in MAC table. Flooding frame on all ports")
+		debug(4, "switchforward", switchID, "Destination address "+dstMAC+" not found in MAC table. Flooding frame on all ports")
 	} else {
 		if isSwitchportID(snet.Router.VSwitch, switchportID) { // VSwitch
 			debug(4, "switchforward", switchID, "Destination address found in MAC table.")

--- a/switch.go
+++ b/switch.go
@@ -9,7 +9,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"strings"
 	"time"
 )
@@ -18,7 +17,6 @@ type Switch struct {
 	ID              string              `json:"id"`
 	Model           string              `json:"model"`
 	Hostname        string              `json:"hostname"`
-	MgmtIP          net.IP              `json:"mgmtip"`
 	MACTable        map[string]MACEntry `json:"mactable"`
 	Maxports        int                 `json:"maxports"`
 	PortLinksRemote []string            `json:"links_remote"` // maps port # to remote link ID

--- a/switch.go
+++ b/switch.go
@@ -114,8 +114,8 @@ func delSwitch(hostname string) {
 				if snet.Switches[i].PortLinksRemote[j] != "" {
 					// Unlink if host
 					for h := range snet.Hosts {
-						if snet.Hosts[h].UplinkID == snet.Switches[i].PortLinksLocal[j] {
-							snet.Hosts[h].UplinkID = ""
+						if snet.Hosts[h].Interface.RemoteL1ID == snet.Switches[i].PortLinksLocal[j] {
+							snet.Hosts[h].Interface.RemoteL1ID = ""
 						}
 					}
 
@@ -238,6 +238,7 @@ func checkMACTable(macaddr string, id string, port int) { // For updating MAC ta
 				debug(4, "checkMACTable", id, "Source address found in MAC table")
 				result = v.Interface
 			} else {
+				debug(4, "checkMACTable", id, "Source address found in MAC table, but wrong - removing old.")
 				delMACEntry(macaddr, id, port)
 			}
 		}
@@ -355,6 +356,7 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 				// Don't send out source interface, or unplugged ports
 				if (snet.Router.VSwitch.PortLinksLocal[port] != switchportID) && (linkID != "") {
 					channels[linkID] <- outFrame
+					fmt.Println("I sent linkid " + linkID + " a frame")
 				}
 			}
 		} else { // Regular switch
@@ -369,6 +371,7 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 		}
 	} else {
 		channels[linkID] <- outFrame
+		fmt.Println("I sent linkid " + linkID + " a frame")
 	}
 }
 

--- a/switch.go
+++ b/switch.go
@@ -356,7 +356,6 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 				// Don't send out source interface, or unplugged ports
 				if (snet.Router.VSwitch.PortLinksLocal[port] != switchportID) && (linkID != "") {
 					channels[linkID] <- outFrame
-					fmt.Println("I sent linkid " + linkID + " a frame")
 				}
 			}
 		} else { // Regular switch
@@ -371,7 +370,6 @@ func switchforward(frame Frame, switchID string, switchportID string) {
 		}
 	} else {
 		channels[linkID] <- outFrame
-		fmt.Println("I sent linkid " + linkID + " a frame")
 	}
 }
 


### PR DESCRIPTION
Features/Improvements:

- Hosts and routers now have interfaces instead of IP configurations on devices themselves
- Each host and router automatically has a loopback interface (127.0.0.1 configured)
- Static hostname resolving (with `nslookup` command). No DNS server resolution yet
- Added a common "sending function", allows devices to communicate to themselves without going out an interface
- Improved end-to-end test
- Added Achievement 4

Bugfixes:

- Fixed issue where switches couldn't learn the router's MAC address
- Devices can now ping/ARP themselves